### PR TITLE
Price save and load to decimal

### DIFF
--- a/SmartReceipts/WBNewReceiptViewController.m
+++ b/SmartReceipts/WBNewReceiptViewController.m
@@ -344,8 +344,8 @@ static const int TAG_CURRENCY = 1, TAG_CATEGORY = 2;
                                  dateMs:_dateMs
                            timeZoneName:[_timeZone name]
                                 comment:self.commentField.text
-                                  price:[NSDecimalNumber decimalNumberWithString:self.priceTextField.text]
-                                    tax:[NSDecimalNumber decimalNumberWithString:self.taxTextField.text]
+                                  price:[NSDecimalNumber decimalNumberWithString:self.priceTextField.text locale:[NSLocale currentLocale]]
+                                    tax:[NSDecimalNumber decimalNumberWithString:self.taxTextField.text locale:[NSLocale currentLocale]]
                            currencyCode:[self.currencyButton titleForState:UIControlStateNormal]
                            isExpensable:self.expensableSwitch.on
                              isFullPage:self.fullPageImageSwitch.on
@@ -367,8 +367,8 @@ static const int TAG_CURRENCY = 1, TAG_CATEGORY = 2;
                               category:[self.categoryButton.titleLabel text]
                                 dateMs:_dateMs
                                comment:self.commentField.text
-                                 price:[NSDecimalNumber decimalNumberWithString:self.priceTextField.text]
-                                   tax:[NSDecimalNumber decimalNumberWithString:self.taxTextField.text]
+                                 price:[NSDecimalNumber decimalNumberWithString:self.priceTextField.text locale:[NSLocale currentLocale]]
+                                   tax:[NSDecimalNumber decimalNumberWithString:self.taxTextField.text locale:[NSLocale currentLocale]]
                           currencyCode:[self.currencyButton.titleLabel text]
                           isExpensable:self.expensableSwitch.on
                             isFullPage:self.fullPageImageSwitch.on

--- a/SmartReceipts/WBReceiptsHelper.m
+++ b/SmartReceipts/WBReceiptsHelper.m
@@ -111,7 +111,7 @@ static NSString * const COLUMN_EXTRA_EDITTEXT_3 = @"extra_edittext_3";
         const int extra_edittext_3_Index = [resultSet columnIndexForName:COLUMN_EXTRA_EDITTEXT_3];
         
         while ([resultSet next]) {
-            
+
             WBReceipt *receipt =
             [[WBReceipt alloc] initWithId:[resultSet intForColumnIndex:idIndex]
                                      name:[resultSet stringForColumnIndex:nameIndex]
@@ -120,8 +120,8 @@ static NSString * const COLUMN_EXTRA_EDITTEXT_3 = @"extra_edittext_3";
                                    dateMs:[resultSet longLongIntForColumnIndex:dateIndex]
                              timeZoneName:[resultSet stringForColumnIndex:timeZoneIndex]
                                   comment:[resultSet stringForColumnIndex:commentIndex]
-                                    price:[[NSDecimalNumber alloc] initWithDouble:[resultSet doubleForColumnIndex:priceIndex]]
-                                      tax:[[NSDecimalNumber alloc] initWithDouble:[resultSet doubleForColumnIndex:taxIndex]]
+                                    price:[NSDecimalNumber decimalNumberWithString:[resultSet stringForColumnIndex:priceIndex]]
+                                      tax:[NSDecimalNumber decimalNumberWithString:[resultSet stringForColumnIndex:taxIndex]]
                              currencyCode:[resultSet stringForColumnIndex:currencyIndex]
                              isExpensable:[resultSet boolForColumnIndex:expenseableIndex]
                                isFullPage:![resultSet boolForColumnIndex:fullpageIndex]
@@ -148,7 +148,6 @@ static NSString * const COLUMN_EXTRA_EDITTEXT_3 = @"extra_edittext_3";
         FMResultSet* resultSet = [database executeQuery:query, [NSNumber numberWithInt:receiptId] ];
         
         if ([resultSet next]) {
-            
             receipt =
             [[WBReceipt alloc] initWithId:[resultSet intForColumn:COLUMN_ID]
                                      name:[resultSet stringForColumn:COLUMN_NAME]
@@ -157,8 +156,8 @@ static NSString * const COLUMN_EXTRA_EDITTEXT_3 = @"extra_edittext_3";
                                    dateMs:[resultSet longLongIntForColumn:COLUMN_DATE]
                              timeZoneName:[resultSet stringForColumn:COLUMN_TIMEZONE]
                                   comment:[resultSet stringForColumn:COLUMN_COMMENT]
-                                    price:[[NSDecimalNumber alloc] initWithDouble:[resultSet doubleForColumn:COLUMN_PRICE]]
-                                      tax:[[NSDecimalNumber alloc] initWithDouble:[resultSet doubleForColumn:COLUMN_TAX]]
+                                    price:[NSDecimalNumber decimalNumberWithString:[resultSet stringForColumn:COLUMN_PRICE]]
+                                      tax:[NSDecimalNumber decimalNumberWithString:[resultSet stringForColumn:COLUMN_TAX]]
                              currencyCode:[resultSet stringForColumn:COLUMN_ISO4217]
                              isExpensable:[resultSet boolForColumn:COLUMN_EXPENSEABLE]
                                isFullPage:![resultSet boolForColumn:COLUMN_NOTFULLPAGEIMAGE]
@@ -269,12 +268,12 @@ static NSString* addExtra(WBSqlBuilder* builder, NSString* extra) {
     [qBuilder addColumn:COLUMN_NOTFULLPAGEIMAGE
              andBoolean:!isFullPage];
     
-    if (price != 0) {
+    if (![price isEqualToNumber:[NSDecimalNumber zero]]) {
         [qBuilder addColumn:COLUMN_PRICE
                   andObject:price];
     }
     
-    if (tax != 0) {
+    if (![tax isEqualToNumber:[NSDecimalNumber zero]]) {
         [qBuilder addColumn:COLUMN_TAX
                   andObject:tax];
     }


### PR DESCRIPTION
With this change receipt amounts should always be saved using NSDecimalNumber. And on load value is loaded as String and parsed using NSDecimalNumber.

Only place where locale comes to play is in when adding receipt. There string is parsed with locale. Meaning that correct number will always be parsed even when locale is using comma separator. 

After that saving to database and loading from database is done with period as decimal separator. It's system default presentation.