### PR TITLE
Extracted image picker to separate class

### DIFF
--- a/SmartReceipts.xcodeproj/project.pbxproj
+++ b/SmartReceipts.xcodeproj/project.pbxproj
@@ -136,6 +136,7 @@
 		EA3CF0971AE77E1900B14B73 /* WBPrice.m in Sources */ = {isa = PBXBuildFile; fileRef = EA3CF0961AE77E1900B14B73 /* WBPrice.m */; };
 		EA3CF09B1AE7964900B14B73 /* NSDecimalNumber+WBNumberParse.m in Sources */ = {isa = PBXBuildFile; fileRef = EA3CF09A1AE7964900B14B73 /* NSDecimalNumber+WBNumberParse.m */; };
 		EA3CF09E1AE7C45C00B14B73 /* Constants.m in Sources */ = {isa = PBXBuildFile; fileRef = EA3CF09D1AE7C45C00B14B73 /* Constants.m */; };
+		EA46678F1AE7EA1700B4E502 /* WBImagePicker.m in Sources */ = {isa = PBXBuildFile; fileRef = EA46678E1AE7EA1600B4E502 /* WBImagePicker.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -383,6 +384,8 @@
 		EA3CF09A1AE7964900B14B73 /* NSDecimalNumber+WBNumberParse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDecimalNumber+WBNumberParse.m"; sourceTree = "<group>"; };
 		EA3CF09C1AE7C45C00B14B73 /* Constants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Constants.h; sourceTree = "<group>"; };
 		EA3CF09D1AE7C45C00B14B73 /* Constants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Constants.m; sourceTree = "<group>"; };
+		EA46678D1AE7EA1600B4E502 /* WBImagePicker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WBImagePicker.h; sourceTree = "<group>"; };
+		EA46678E1AE7EA1600B4E502 /* WBImagePicker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WBImagePicker.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -935,6 +938,7 @@
 			children = (
 				4DF22941192867120008D359 /* Ads */,
 				EA3CF0981AE7962C00B14B73 /* Extensions */,
+				EA46678C1AE7EA0300B4E502 /* Utils */,
 				848EFA5D18EDC33F00AC01B4 /* reports */,
 				84D6719818D34E3200B704A4 /* util */,
 				847EFA5118E6BBF3006BE520 /* persistence */,
@@ -992,6 +996,15 @@
 				EA3CF09A1AE7964900B14B73 /* NSDecimalNumber+WBNumberParse.m */,
 			);
 			path = Extensions;
+			sourceTree = "<group>";
+		};
+		EA46678C1AE7EA0300B4E502 /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				EA46678D1AE7EA1600B4E502 /* WBImagePicker.h */,
+				EA46678E1AE7EA1600B4E502 /* WBImagePicker.m */,
+			);
+			path = Utils;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1240,6 +1253,7 @@
 				8453368018F475E2001072AA /* WBAutocompleteHelper.m in Sources */,
 				8472F01818D6F50B00929C5B /* WBNewTripViewController.m in Sources */,
 				845E33EF18D8AE2E006A506A /* WBTrip.m in Sources */,
+				EA46678F1AE7EA1700B4E502 /* WBImagePicker.m in Sources */,
 				84ABACF718DB66FA00F8D3EB /* FMDatabaseAdditions.m in Sources */,
 				848EFA6018EDC37100AC01B4 /* WBTripPdfCreator.m in Sources */,
 			);

--- a/SmartReceipts/Utils/WBImagePicker.h
+++ b/SmartReceipts/Utils/WBImagePicker.h
@@ -1,0 +1,18 @@
+//
+//  WBImagePicker.h
+//  SmartReceipts
+//
+//  Created by Jaanus Siim on 22/04/15.
+//  Copyright (c) 2015 Will Baumann. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+typedef void (^WBImagePickerResultBlock)(UIImage *image);
+
+@interface WBImagePicker : NSObject
+
++ (instancetype)sharedInstance;
+- (void)presentPickerOnController:(UIViewController *)controller completion:(WBImagePickerResultBlock)completion;
+
+@end

--- a/SmartReceipts/Utils/WBImagePicker.m
+++ b/SmartReceipts/Utils/WBImagePicker.m
@@ -1,0 +1,106 @@
+//
+//  WBImagePicker.m
+//  SmartReceipts
+//
+//  Created by Jaanus Siim on 22/04/15.
+//  Copyright (c) 2015 Will Baumann. All rights reserved.
+//
+
+#import <UIAlertView-Blocks/RIButtonItem.h>
+#import <UIAlertView-Blocks/UIActionSheet+Blocks.h>
+#import "WBImagePicker.h"
+#import "Constants.h"
+#import "WBImageUtils.h"
+#import "WBPreferences.h"
+
+@interface WBImagePicker () <UINavigationControllerDelegate, UIImagePickerControllerDelegate>
+
+@property (nonatomic, copy) WBImagePickerResultBlock selectionHandler;
+
+@end
+
+@implementation WBImagePicker
+
++ (instancetype)sharedInstance {
+    DEFINE_SHARED_INSTANCE_USING_BLOCK(^{
+        return [[self alloc] initSingleton];
+    });
+}
+
+- (id)init {
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:[NSString stringWithFormat:@"You must use [%@ %@] instead",
+                                                                     NSStringFromClass([self class]),
+                                                                     NSStringFromSelector(@selector(sharedInstance))]
+                                 userInfo:nil];
+    return nil;
+}
+
+- (id)initSingleton {
+    self = [super init];
+    if (self) {
+        // Custom initialization code
+    }
+    return self;
+}
+
+- (void)presentPickerOnController:(UIViewController *)controller completion:(WBImagePickerResultBlock)completion {
+    [self setSelectionHandler:completion];
+
+    BOOL hasCamera = [UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera];
+    if (!hasCamera) {
+        [self presentImagePickerWithSource:UIImagePickerControllerSourceTypePhotoLibrary onController:controller];
+        return;
+    }
+
+    void (^cancelAction)() = ^{
+        [self setSelectionHandler:nil];
+    };
+    void (^chooseFromLibraryAction)() = ^{
+        [self presentImagePickerWithSource:UIImagePickerControllerSourceTypePhotoLibrary onController:controller];
+    };
+    void (^takeImageAction)() = ^{
+        [self presentImagePickerWithSource:UIImagePickerControllerSourceTypeCamera onController:controller];
+    };
+
+    UIActionSheet *actionSheet = [[UIActionSheet alloc] initWithTitle:NSLocalizedString(@"Select image from", nil)
+                                                     cancelButtonItem:[RIButtonItem itemWithLabel:NSLocalizedString(@"Cancel", nil) action:cancelAction]
+                                                destructiveButtonItem:nil
+                                                     otherButtonItems:[RIButtonItem itemWithLabel:NSLocalizedString(@"Choose Existing", nil) action:chooseFromLibraryAction],
+                                                                      [RIButtonItem itemWithLabel:NSLocalizedString(@"Take Photo", nil) action:takeImageAction], nil];
+    [actionSheet showInView:controller.view];
+}
+
+- (void)presentImagePickerWithSource:(UIImagePickerControllerSourceType)source onController:(UIViewController *)controller {
+    UIImagePickerController *picker = [[UIImagePickerController alloc] init];
+    picker.delegate = self;
+    picker.sourceType = source;
+
+    [controller presentViewController:picker animated:YES completion:NULL];
+}
+
+- (void)imagePickerController:(UIImagePickerController *)picker didFinishPickingMediaWithInfo:(NSDictionary *)info {
+    UIImage *chosenImage = info[UIImagePickerControllerOriginalImage];
+
+    int size = [WBPreferences cameraMaxHeightWidth];
+    if (size > 0) {
+        chosenImage = [WBImageUtils image:chosenImage scaledToFitSize:CGSizeMake(size, size)];
+    }
+
+    [picker dismissViewControllerAnimated:YES completion:^{
+        self.selectionHandler(chosenImage);
+        [self setSelectionHandler:nil];
+    }];
+}
+
+- (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker {
+    self.selectionHandler(nil);
+    [self setSelectionHandler:nil];
+    [picker dismissViewControllerAnimated:YES completion:NULL];
+}
+
+- (void)navigationController:(UINavigationController *)navigationController willShowViewController:(UIViewController *)viewController animated:(BOOL)animated {
+    [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleLightContent];
+}
+
+@end

--- a/SmartReceipts/WBImageViewController.h
+++ b/SmartReceipts/WBImageViewController.h
@@ -10,7 +10,7 @@
 
 #import "WBReceiptsViewController.h"
 
-@interface WBImageViewController : WBViewController<UIScrollViewDelegate,UINavigationControllerDelegate, UIImagePickerControllerDelegate>
+@interface WBImageViewController : WBViewController<UIScrollViewDelegate>
 
 @property (strong) NSString *path;
 @property (strong) NSString *name;

--- a/SmartReceipts/WBImageViewController.m
+++ b/SmartReceipts/WBImageViewController.m
@@ -13,7 +13,7 @@
 
 #import "WBImageUtils.h"
 #import "WBFileManager.h"
-#import "WBPreferences.h"
+#import "WBImagePicker.h"
 
 @interface WBImageViewController ()
 {
@@ -88,38 +88,6 @@
     });
 }
 
-- (void)imagePickerController:(UIImagePickerController *)picker didFinishPickingMediaWithInfo:(NSDictionary *)info {
-    
-    UIImage *chosenImage = info[UIImagePickerControllerOriginalImage];
-    
-    int size = [WBPreferences cameraMaxHeightWidth];
-    if (size > 0) {
-        chosenImage = [WBImageUtils image:chosenImage scaledToFitSize:CGSizeMake(size, size)];
-    }
-    
-    [picker dismissViewControllerAnimated:YES completion:^{
-        if (chosenImage) {
-            image = chosenImage;
-            
-            NSData *data;
-            if([[self.path pathExtension] caseInsensitiveCompare:@"png"] == NSOrderedSame) {
-                data = UIImagePNGRepresentation(image);
-            } else {
-                data = UIImageJPEGRepresentation(image, 0.85);
-            }
-            
-            [WBFileManager forceWriteData:data to:self.path];
-            
-            [self refreshSizes];
-        }
-    }];
-    
-}
-
-- (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker {
-    [picker dismissViewControllerAnimated:YES completion:NULL];
-}
-
 - (IBAction)actionRotateCcw:(id)sender {
     [self rotateToOrientation:UIImageOrientationLeft];
 }
@@ -129,6 +97,25 @@
 }
 
 - (IBAction)actionCamera:(id)sender {
-    [WBReceiptsViewController takePhotoWithViewController:self];
+    [[WBImagePicker sharedInstance] presentPickerOnController:self completion:^(UIImage *picked) {
+        if (!picked) {
+            return;
+        }
+
+        UIImage *chosenImage = picked;
+
+        image = chosenImage;
+
+        NSData *data;
+        if ([[self.path pathExtension] caseInsensitiveCompare:@"png"] == NSOrderedSame) {
+            data = UIImagePNGRepresentation(image);
+        } else {
+            data = UIImageJPEGRepresentation(image, 0.85);
+        }
+
+        [WBFileManager forceWriteData:data to:self.path];
+
+        [self refreshSizes];
+    }];
 }
 @end

--- a/SmartReceipts/WBReceiptActionsViewController.h
+++ b/SmartReceipts/WBReceiptActionsViewController.h
@@ -14,10 +14,11 @@
 
 #import <QuickLook/QuickLook.h>
 
-@interface WBReceiptActionsViewController : WBTableViewController<UIDocumentInteractionControllerDelegate,UINavigationControllerDelegate, UIImagePickerControllerDelegate>
-- (IBAction)actionDone:(id)sender;
+@interface WBReceiptActionsViewController : WBTableViewController<UIDocumentInteractionControllerDelegate>
 
 @property (weak,nonatomic) WBReceiptsViewController* receiptsViewController;
 @property WBReceipt* receipt;
+
+- (IBAction)actionDone:(id)sender;
 
 @end

--- a/SmartReceipts/WBReceiptActionsViewController.m
+++ b/SmartReceipts/WBReceiptActionsViewController.m
@@ -12,12 +12,8 @@
 
 #import "WBImageViewController.h"
 
-#import "WBReceipt.h"
-
 #import "WBAppDelegate.h"
-
-#import "WBPreferences.h"
-#import "WBImageUtils.h"
+#import "WBImagePicker.h"
 
 @interface WBReceiptActionsViewController ()
 
@@ -183,7 +179,7 @@
         }
         case 2: {
             // take / replace receipt image
-            [WBReceiptsViewController takePhotoWithViewController:self];
+            [self takePhoto];
             break;
         }
         case 3:
@@ -211,26 +207,15 @@
     [tableView deselectRowAtIndexPath:indexPath animated:YES];
 }
 
-- (void)imagePickerController:(UIImagePickerController *)picker didFinishPickingMediaWithInfo:(NSDictionary *)info {
-    
-    UIImage *chosenImage = info[UIImagePickerControllerOriginalImage];
-    
-    int size = [WBPreferences cameraMaxHeightWidth];
-    if (size > 0) {
-        chosenImage = [WBImageUtils image:chosenImage scaledToFitSize:CGSizeMake(size, size)];
-    }
-    
-    [picker dismissViewControllerAnimated:YES completion:^{
-        if (chosenImage) {
-            [self.receiptsViewController updateReceipt:self.receipt image:chosenImage];
-            [self createCellsTextsAndIndices];
+- (void)takePhoto {
+    [[WBImagePicker sharedInstance] presentPickerOnController:self completion:^(UIImage *image) {
+        if (!image) {
+            return;
         }
-    }];
-    
-}
 
-- (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker {
-    [picker dismissViewControllerAnimated:YES completion:NULL];
+        [self.receiptsViewController updateReceipt:self.receipt image:image];
+        [self createCellsTextsAndIndices];
+    }];
 }
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView

--- a/SmartReceipts/WBReceiptsViewController.h
+++ b/SmartReceipts/WBReceiptsViewController.h
@@ -19,7 +19,7 @@
 
 @end
 
-@interface WBReceiptsViewController : WBTableViewController<UINavigationControllerDelegate,UIImagePickerControllerDelegate,UIAlertViewDelegate,WBObservableReceiptsDelegate,WBNewReceiptViewControllerDelegate,UITextFieldDelegate>
+@interface WBReceiptsViewController : WBTableViewController<UIAlertViewDelegate,WBObservableReceiptsDelegate,WBNewReceiptViewControllerDelegate,UITextFieldDelegate>
 
 @property (weak,nonatomic) id<WBReceiptsViewControllerDelegate> delegate;
 
@@ -35,8 +35,6 @@
 - (void) swapDownReceipt:(WBReceipt*) receipt;
 
 - (BOOL) attachPdfOrImageFile:(NSString*)pdfFile toReceipt:(WBReceipt*) receipt;
-
-+ (void)takePhotoWithViewController:(UIViewController <UINavigationControllerDelegate, UIImagePickerControllerDelegate> *)vcDelegate;
 
 - (void) notifyReceiptRemoved:(WBReceipt*) receipt;
 - (BOOL) updateReceipt:(WBReceipt*) receipt image:(UIImage*) image;


### PR DESCRIPTION
Extracted image picker presentation to separate class. This enabled single place to handle picker callbacks (needed to reset status bar color). 

This also allowed me to remove some copy/paste code related to image picker delegate methods