### PR TITLE
Negative number entry

### DIFF
--- a/SmartReceipts/Cells/TextEntryCell.h
+++ b/SmartReceipts/Cells/TextEntryCell.h
@@ -21,5 +21,6 @@
 - (void)activateNumberEntryMode;
 - (void)activateEmailMode;
 - (void)setValue:(NSString *)value;
+- (void)addAccessoryViewWithNegativeSwitch;
 
 @end

--- a/SmartReceipts/Cells/TextEntryCell.m
+++ b/SmartReceipts/Cells/TextEntryCell.m
@@ -44,7 +44,7 @@
 
 - (void)addAccessoryView {
     UIBarButtonItem *doneButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(donePressed)];
-    UIToolbar *toolbar = [[UIToolbar alloc] initWithFrame:CGRectMake(0, 0, 100, 44)];
+    UIToolbar *toolbar = [[UIToolbar alloc] initWithFrame:CGRectMake(0, 0, 320, 44)];
     [toolbar setBarStyle:UIBarStyleDefault];
     [toolbar setAutoresizingMask:UIViewAutoresizingFlexibleWidth];
     UIBarButtonItem *spacer = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil];
@@ -60,6 +60,24 @@
 - (void)setValue:(NSString *)value {
     [self.entryField setText:value];
 }
+
+- (void)addAccessoryViewWithNegativeSwitch {
+    UISegmentedControl *segmentedControl = [[UISegmentedControl alloc] initWithItems:@[@"+", @"-"]];
+    CGRect segmentFrame = segmentedControl.frame;
+    segmentFrame.size.width = 100;
+    [segmentedControl setFrame:segmentFrame];
+    [segmentedControl setSelectedSegmentIndex:0];
+
+    UIBarButtonItem *doneButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(donePressed)];
+    UIToolbar *toolbar = [[UIToolbar alloc] initWithFrame:CGRectMake(0, 0, 320, 44)];
+    [toolbar setBarStyle:UIBarStyleDefault];
+    [toolbar setAutoresizingMask:UIViewAutoresizingFlexibleWidth];
+    UIBarButtonItem *spacer = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil];
+    [toolbar setItems:@[[[UIBarButtonItem alloc] initWithCustomView:segmentedControl], spacer, doneButton]];
+
+    [self.entryField setInputAccessoryView:toolbar];
+}
+
 
 - (void)donePressed {
     [self.entryField.delegate textFieldShouldReturn:self.entryField];

--- a/SmartReceipts/ViewControllers/EditReceiptViewController.m
+++ b/SmartReceipts/ViewControllers/EditReceiptViewController.m
@@ -98,11 +98,14 @@ NSString *const SREditReceiptCategoryCacheKey = @"SREditReceiptCategoryCacheKey"
     self.priceCell.title = NSLocalizedString(@"edit.receipt.price.label", nil);
     [self.priceCell setPlaceholder:NSLocalizedString(@"edit.receipt.price.placeholder", nil)];
     [self.priceCell activateDecimalEntryMode];
+    [self.priceCell.entryField setKeyboardType:UIKeyboardTypeNumbersAndPunctuation];
+    [self.priceCell.entryField setInputAccessoryView:nil];
 
     self.taxCell = [self.tableView dequeueReusableCellWithIdentifier:[TitledTextEntryCell cellIdentifier]];
     [self.taxCell setTitle:NSLocalizedString(@"edit.receipt.tax.label", nil)];
     [self.taxCell setPlaceholder:NSLocalizedString(@"edit.receipt.tax.placeholder", nil)];
     [self.taxCell activateDecimalEntryMode];
+    [self.taxCell addAccessoryViewWithNegativeSwitch];
 
     if ([WBPreferences includeTaxField]) {
         TaxCalculator *calculator = [[TaxCalculator alloc] initWithSourceField:self.priceCell.entryField targetField:self.taxCell.entryField];


### PR DESCRIPTION
This pull contains demo of two options I see. 

We can use keyboard that allows minus sign entry. Or we could add button to keyboard that specifies if positive or negative number is entered.

When you enable tax field entry and open receipt edit screen, price field will use the first option. Tax field will use the second option.

Switching to first option adds no extra work. Switching to second option will add some additional logic to insert/delete minus sign to entry and not allowing user to delete it.