### PR TITLE
Fix: freezing upon performing a manual backup

### DIFF
--- a/SmartReceipts.xcodeproj/project.pbxproj
+++ b/SmartReceipts.xcodeproj/project.pbxproj
@@ -428,7 +428,7 @@
 		5785A4EE1E09DA0100C3CA0C /* AnalyticsLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnalyticsLogger.swift; sourceTree = "<group>"; };
 		579DDFB11E2E4223004937F7 /* UIImage+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+Extensions.swift"; sourceTree = "<group>"; };
 		57A8058C1E9672C000E68049 /* DatabaseUpgrade15Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseUpgrade15Tests.swift; sourceTree = "<group>"; };
-		57A8058E1E9799AC00E68049 /* android-receipts-v15.db */ = {isa = PBXFileReference; lastKnownFileType = file; name = "android-receipts-v15.db"; path = "SmartReceiptsTests/Persistence/TestData/android-receipts-v15.db"; sourceTree = "<group>"; };
+		57A8058E1E9799AC00E68049 /* android-receipts-v15.db */ = {isa = PBXFileReference; lastKnownFileType = file; path = "android-receipts-v15.db"; sourceTree = "<group>"; };
 		57C0EED01E2AE972001B4758 /* CustomLogFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomLogFormatter.swift; sourceTree = "<group>"; };
 		57C0EED21E2D2D3E001B4758 /* LoggerMacros-ObjC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "LoggerMacros-ObjC.h"; sourceTree = "<group>"; };
 		57C125181E12DAEF008551AC /* ServiceAccount.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ServiceAccount.json; sourceTree = "<group>"; };
@@ -1110,7 +1110,6 @@
 		84F4F33718CFCCD000F69A35 = {
 			isa = PBXGroup;
 			children = (
-				57A8058E1E9799AC00E68049 /* android-receipts-v15.db */,
 				84AA921618EEAE590096013D /* 3rdparty */,
 				84F4F34918CFCCD000F69A35 /* SmartReceipts */,
 				EA8D81D01AEA956600BAC943 /* SmartReceiptsTests */,
@@ -1663,6 +1662,7 @@
 		EA69EF2B1AF0907300276B70 /* TestData */ = {
 			isa = PBXGroup;
 			children = (
+				57A8058E1E9799AC00E68049 /* android-receipts-v15.db */,
 				EAE23CB41B1757590078F197 /* 2015_05_26_SmartReceipts.smr */,
 				EA159E7C1AFE6F4E00DBB6CF /* android-receipts-v11.db */,
 				EA159E7B1AFE6F4E00DBB6CF /* android-receipts-v13.db */,

--- a/SmartReceipts/Reports/Generators/TripImagesPDFGenerator.m
+++ b/SmartReceipts/Reports/Generators/TripImagesPDFGenerator.m
@@ -105,9 +105,14 @@
         LOGGER_ERROR(@"drawFullPagePDFFile: pdf is nil, for path:%@", filePath);
         return;
     }
+    
+    size_t numberOfPages = CGPDFDocumentGetNumberOfPages(pdf);
+    if (numberOfPages > 10) {
+        LOGGER_WARNING(@"Too many pages (%zu) for %@", numberOfPages, label);
+    }
 
     @autoreleasepool {
-        for (NSUInteger i = 0; i < CGPDFDocumentGetNumberOfPages(pdf); ++i) {
+        for (NSUInteger i = 0; i < numberOfPages; ++i) {
             CGPDFPageRef page = CGPDFDocumentGetPage(pdf, i + 1);
             [self.pdfRender appendPDFPage:page withLabel:label];
         }

--- a/SmartReceipts/ViewControllers/SettingsViewController.m
+++ b/SmartReceipts/ViewControllers/SettingsViewController.m
@@ -606,18 +606,17 @@ static NSString *const PushPaymentMethodsControllerSegueIdentifier = @"PushPayme
     
     void (^exportActionBlock)() = ^{
         PendingHUDView *hud = [PendingHUDView showHUDOnView:self.navigationController.view];
+        TICK;
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
             DataExport *export = [[DataExport alloc] initWithWorkDirectory:[WBFileManager documentsPath]];
             NSString *exportPath = [export execute];
-            NSData *exportData = [NSData dataWithContentsOfFile:exportPath];
-            
-            LOGGER_INFO(@"actionExport - exportPath: %@", exportPath);
-            LOGGER_INFO(@"actionExport - exportData_size: %li", exportData.length);
+            BOOL isFileExists = [[NSFileManager defaultManager] fileExistsAtPath:exportPath];
+            LOGGER_INFO(@"actionExport finished: time %@, exportPath: %@", TOCK, exportPath);
             
             dispatch_async(dispatch_get_main_queue(), ^{
                 [hud hide];
-
-                if (exportData) {
+                
+                if (isFileExists) {
                     [self shareBackupFile:exportPath fromRect:[self.tableView convertRect:self.backupCell.frame toView:self.view]];
                 } else {
                     LOGGER_ERROR(@"Failed to properly export data");


### PR DESCRIPTION
The problem was in
NSData *exportData = [NSData dataWithContentsOfFile:exportPath];
This line was used to check for succesfully created file. but.. dataWithContentsOfFile also copies whole file to the RAM.

According to the customer's logfile, looks like the problem was here.