### PR TITLE
Applied translations to our settings page

### DIFF
--- a/SmartReceipts/Modules/Generate Report/GenerateReportShareService.swift
+++ b/SmartReceipts/Modules/Generate Report/GenerateReportShareService.swift
@@ -103,7 +103,7 @@ class GenerateReportShareService: NSObject, MFMailComposeViewControllerDelegate 
     }
     
     fileprivate func split(_ string: String) -> [String] {
-        if (string.contains(",")) {
+        if string.contains(",") {
             // For legacy reasons, we allow these to also be separated by a comma (,)
             return string.components(separatedBy: ",")
         } else {

--- a/SmartReceipts/Modules/Generate Report/GenerateReportShareService.swift
+++ b/SmartReceipts/Modules/Generate Report/GenerateReportShareService.swift
@@ -103,7 +103,12 @@ class GenerateReportShareService: NSObject, MFMailComposeViewControllerDelegate 
     }
     
     fileprivate func split(_ string: String) -> [String] {
-        return string.components(separatedBy: ",")
+        if (string.contains(",")) {
+            // For legacy reasons, we allow these to also be separated by a comma (,)
+            return string.components(separatedBy: ",")
+        } else {
+            return string.components(separatedBy: ";")
+        }
     }
     
     private func remove(files: [String]) {

--- a/SmartReceipts/Modules/Settings/SettingsFormView.swift
+++ b/SmartReceipts/Modules/Settings/SettingsFormView.swift
@@ -52,9 +52,9 @@ class SettingsFormView: FormViewController {
         tableView.separatorColor = UIColor.clear
         
         form
-        +++ Section(LocalizedString("settings.purchase.section.title"))
+        +++ Section(LocalizedString("pref_pro_header"))
         <<< PurchaseButtonRow() { [unowned self] row in
-            row.title = LocalizedString("settings.purchase.pro.label")
+            row.title = LocalizedString("pro_subscription")
             self.purchaseRow = row
         }.onCellSelection({ [unowned self] _, row in
             if !row.isPurchased() {
@@ -108,8 +108,8 @@ class SettingsFormView: FormViewController {
         <<< DescribedSwitchRow() { row in
             row.title = LocalizedString("pref_pro_separate_by_category_title")
             row.value = WBPreferences.separatePaymantsByCategory()
-            row.onSubtitle = LocalizedString("settings.pro.payments.by.category.description.on")
-            row.offSubtitle = LocalizedString("settings.pro.payments.by.category.description.off")
+            row.onSubtitle = LocalizedString("pref_pro_separate_by_category_summaryOn")
+            row.offSubtitle = LocalizedString("pref_pro_separate_by_category_summaryOff")
         }.onChange({ row in
             WBPreferences.setSeparatePaymantsByCategory(row.value!)
         }).cellUpdate({ [unowned self] cell, _ in
@@ -117,10 +117,10 @@ class SettingsFormView: FormViewController {
         })
         
         <<< DescribedSwitchRow() { row in
-            row.title = LocalizedString("settings.pro.categorical.summation.title")
+            row.title = LocalizedString("pref_pro_categorical_summation_title")
             row.value = WBPreferences.includeCategoricalSummation()
-            row.onSubtitle = LocalizedString("settings.pro.categorical.summation.description.on")
-            row.offSubtitle = LocalizedString("settings.pro.categorical.summation.description.off")
+            row.onSubtitle = LocalizedString("pref_pro_categorical_summation_summaryOn")
+            row.offSubtitle = LocalizedString("pref_pro_categorical_summation_summaryOff")
         }.onChange({ row in
             WBPreferences.setIncludeCategoricalSummation(row.value!)
         }).cellUpdate({ [unowned self] cell, _ in
@@ -140,21 +140,21 @@ class SettingsFormView: FormViewController {
         +++ Section(LocalizedString("pref_email_header"))
         <<< textInput(LocalizedString("pref_email_default_email_to_title"),
             value: WBPreferences.defaultEmailRecipient(),
-            placeholder: LocalizedString("settings.default.email.recipient.placeholder"))
+            placeholder: LocalizedString("pref_email_default_email_emptyValue"))
         .onChange({ row in
             WBPreferences.setDefaultEmailRecipient(row.value ?? "")
         })
         
         <<< textInput(LocalizedString("pref_email_default_email_cc_title"),
             value: WBPreferences.defaultEmailCC(),
-            placeholder: LocalizedString("settings.default.email.cc.placeholder"))
+            placeholder: LocalizedString("pref_email_default_email_emptyValue"))
         .onChange({ row in
             WBPreferences.setDefaultEmailCC(row.value ?? "")
         })
             
-        <<< textInput(LocalizedString("settings.default.email.bcc.label"),
+        <<< textInput(LocalizedString("pref_email_default_email_bcc_title"),
             value: WBPreferences.defaultEmailBCC(),
-            placeholder: LocalizedString("settings.default.email.bcc.placeholder"))
+            placeholder: LocalizedString("pref_email_default_email_emptyValue"))
         .onChange({ row in
             WBPreferences.setDefaultEmailBCC(row.value ?? "")
         })
@@ -167,7 +167,7 @@ class SettingsFormView: FormViewController {
 
         +++ Section(LocalizedString("pref_general_header"))
         <<< DescribedSwitchRow() { row in
-            row.title = LocalizedString("settings.enable.autocomplete.label")
+            row.title = LocalizedString("pref_receipt_enable_autocomplete_title")
             row.onSubtitle = LocalizedString("pref_receipt_enable_autocomplete_summary")
             row.offSubtitle = row.onSubtitle
             row.value = WBPreferences.isAutocompleteEnabled()
@@ -176,8 +176,7 @@ class SettingsFormView: FormViewController {
         })
             
         <<< IntRow() { row in
-            row.title = LocalizedString("settings.default.trip.length.label")
-            row.placeholder = LocalizedString("settings.default.trip.length.placeholder")
+            row.title = LocalizedString("pref_general_trip_duration_title")
             row.value = Int(WBPreferences.defaultTripDuration())
         }.onChange({ row in
             let intValue = row.value ?? 0
@@ -197,10 +196,10 @@ class SettingsFormView: FormViewController {
         })
             
         <<< DecimalRow() { row in
-            row.title = LocalizedString("settings.min.receipt.price.label")
+            row.title = LocalizedString("pref_receipt_minimum_receipts_price_title")
+            row.placeholder = LocalizedString("DIALOG_RECEIPTMENU_HINT_PRICE_SHORT")
             let value = WBPreferences.minimumReceiptPriceToIncludeInReports()
             row.value = value == WBPreferences.min_FLOAT() || value == Float(Int32.min) ? nil : Double(value)
-            row.placeholder = LocalizedString("RECEIPTMENU_FIELD_PRICE")
         }.onChange({ row in
             let value = row.value == nil ? WBPreferences.min_FLOAT() : Float(row.value!)
             WBPreferences.setMinimumReceiptPriceToIncludeInReports(value)
@@ -216,11 +215,6 @@ class SettingsFormView: FormViewController {
         .onChange({ row in
             WBPreferences.setUserID(row.value ?? "")
         })
-        <<< textInput(LocalizedString("settings.name.label"),
-            value: WBPreferences.fullName())
-        .onChange({ row in
-            WBPreferences.setFullName(row.value ?? "")
-        })
 
         <<< PickerInlineRow<String>() { row in
             row.title = LocalizedString("pref_general_default_currency_title")
@@ -232,7 +226,7 @@ class SettingsFormView: FormViewController {
             cell.detailTextLabel?.textColor = AppTheme.primaryColor
         })
             
-        <<< segmentedRow(LocalizedString("settings.date.separator.label"),
+        <<< segmentedRow(LocalizedString("pref_general_default_date_separator_title"),
             options: ["-", "/", "."], selectedOption: WBPreferences.dateSeparator())
         .onChange({ row in
             WBPreferences.setDateSeparator(row.selectedOption)
@@ -257,7 +251,7 @@ class SettingsFormView: FormViewController {
         })
             
         <<< DescribedSwitchRow() { row in
-            row.title = LocalizedString("settings.include.tax.field.label")
+            row.title = LocalizedString("pref_receipt_include_tax_field_title")
             row.onSubtitle = LocalizedString("pref_receipt_include_tax_field_summary")
             row.offSubtitle = row.onSubtitle
             row.value = WBPreferences.includeTaxField()
@@ -280,7 +274,7 @@ class SettingsFormView: FormViewController {
         })
         
         <<< DescribedSwitchRow() { row in
-            row.title = LocalizedString("settings.receipt.assume.full.page.image.label")
+            row.title = LocalizedString("pref_receipt_full_page_title")
             row.onSubtitle = LocalizedString("pref_receipt_full_page_summary")
             row.offSubtitle = row.onSubtitle
             row.value = WBPreferences.assumeFullPage()
@@ -298,7 +292,7 @@ class SettingsFormView: FormViewController {
         })
         
         <<< DescribedSwitchRow() { row in
-            row.title = LocalizedString("settings.match.comments.to.categories")
+            row.title = LocalizedString("pref_receipt_match_comment_to_category_title")
             row.onSubtitle = LocalizedString("pref_receipt_match_comment_to_category_summary")
             row.offSubtitle = row.onSubtitle
             row.value = WBPreferences.matchCommentToCategory()
@@ -307,7 +301,7 @@ class SettingsFormView: FormViewController {
         })
         
         <<< DescribedSwitchRow() { row in
-            row.title = LocalizedString("settings.only.report.reimbursable.label")
+            row.title = LocalizedString("pref_receipt_reimbursable_only_title")
             row.onSubtitle = LocalizedString("pref_receipt_reimbursable_only_summary")
             row.offSubtitle = row.onSubtitle
             row.value = WBPreferences.onlyIncludeReimbursableReceiptsInReports()
@@ -323,7 +317,7 @@ class SettingsFormView: FormViewController {
         })
         
         <<< DescribedSwitchRow() { row in
-            row.title = LocalizedString("settings.default.receipt.date.to.start.date.label")
+            row.title = LocalizedString("pref_receipt_default_to_report_start_date_title")
             row.onSubtitle = LocalizedString("pref_receipt_default_to_report_start_date_summary")
             row.offSubtitle = row.onSubtitle
             row.value = WBPreferences.defaultToFirstReportDate()
@@ -374,12 +368,7 @@ class SettingsFormView: FormViewController {
             subtitle: LocalizedString("pref_receipt_customize_categories_summary"), route: .categories)
         
         +++ Section(LocalizedString("pref_output_custom_csv_title"))
-        <<< switchRow(LocalizedString("settings.csv.include.header.columns.label"),
-            value: WBPreferences.includeCSVHeaders())
-        .onChange({ row in
-            WBPreferences.setIncludeCSVHeaders(row.value!)
-        })
-        <<< openModuleButton(LocalizedString("settings.csv.configure.columns.label"),
+        <<< openModuleButton(LocalizedString("pref_output_custom_csv_title"),
             route: .columns(isCSV: true))
     
         +++ Section(LocalizedString("pref_output_custom_pdf_title"))
@@ -413,7 +402,7 @@ class SettingsFormView: FormViewController {
             WBPreferences.setPreferedRawPDFSize(PDFPageSize.pdfPageSizeBy(index: row.value!).rawValue)
         })
 
-        <<< openModuleButton(LocalizedString("settings.pdf.configure.columns.label"),
+        <<< openModuleButton(LocalizedString("pref_output_custom_pdf_title"),
             route: .columns(isCSV: false))
         
         +++ Section(LocalizedString("pref_distance_header"))
@@ -450,7 +439,7 @@ class SettingsFormView: FormViewController {
             WBPreferences.setPrintDailyDistanceValues(row.value!)
         })
         
-        +++ Section(LocalizedString("settings.layout.section.title"))
+        +++ Section(LocalizedString("pref_layout_header"))
         <<< DescribedSwitchRow() { row in
             row.title = LocalizedString("pref_layout_display_date_title")
             row.onSubtitle = LocalizedString("pref_layout_display_date_summary")
@@ -511,14 +500,14 @@ class SettingsFormView: FormViewController {
             WBPreferences.setAdPersonalizationEnabled(row.value!)
         })
     
-        +++ Section(LocalizedString("settings.feedback.section.label"))
-        <<< openModuleButton(LocalizedString("settings.feedback.sendLove.label"),
+        +++ Section(LocalizedString("pref_help_header"))
+        <<< openModuleButton(LocalizedString("pref_help_send_love_title"),
             route: .sendLove)
-        <<< openModuleButton(LocalizedString("settings.feedback.sendFeedback.label"),
+        <<< openModuleButton(LocalizedString("pref_help_send_feedback_title"),
             onTap: { [unowned self] in
             self.settingsView.sendFeedback(subject: FeedbackEmailSubject)
         })
-        <<< openModuleButton(LocalizedString("settings.feedback.sendBugReport.label"),
+        <<< openModuleButton(LocalizedString("pref_help_support_email_title"),
             onTap: { [unowned self] in
             self.settingsView.sendFeedback(subject: FeedbackBugreportEmailSubject)
         })

--- a/SmartReceipts/Persistence/WBPreferences.h
+++ b/SmartReceipts/Persistence/WBPreferences.h
@@ -61,9 +61,6 @@
 + (BOOL)defaultToFirstReportDate;
 + (void)setDefaultToFirstReportDate:(BOOL)defaultToFirstReportDate;
 
-+ (BOOL)includeCSVHeaders;
-+ (void)setIncludeCSVHeaders:(BOOL)includeCSVHeaders;
-
 + (BOOL)isTheDistancePriceBeIncludedInReports;
 + (void)setTheDistancePriceBeIncludedInReports:(BOOL)value;
 

--- a/SmartReceipts/Persistence/WBPreferences.m
+++ b/SmartReceipts/Persistence/WBPreferences.m
@@ -26,7 +26,6 @@ static NSString * const INT_DEFAULT_TRIP_DURATION = @"TripDuration";
 static NSString * const BOOL_ALLOW_DATA_OUTSIDE_TRIP_BOUNDS = @"AllowDataOutsideTripBounds";
 static NSString * const BOOL_AUTOCOMPLETE_ENABLED = @"IsAutocompleteEnabled";
 static NSString * const STRING_USERNAME = @"UserName";
-static NSString * const STRING_FULLNAME = @"FullName";
 static NSString * const BOOL_PREDICT_CATEGORIES = @"PredictCats";
 static NSString * const BOOL_MATCH_COMMENT_WITH_CATEGORIES = @"MatchCommentCats";
 static NSString * const BOOL_MATCH_NAME_WITH_CATEGORIES = @"MatchNameCats";
@@ -39,7 +38,6 @@ static NSString * const STRING_CURRENCY = @"isocurr";
 static NSString * const STRING_DATE_SEPARATOR = @"dateseparator";
 static NSString * const FLOAT_MIN_RECEIPT_PRICE = @"MinReceiptPrice";
 // static NSString * const INT_VERSION_CODE = @"VersionCode";
-static NSString * const BOOL_INCL_CSV_HEADERS = @"IncludeCSVHeaders";
 static NSString * const BOOL_DEFAULT_TO_FIRST_TRIP_DATE = @"DefaultToFirstReportDate";
 // static NSString * const STRING_LAST_ACTIVITY_TAG = @"LastActivityTag";
 
@@ -128,11 +126,9 @@ static NSDictionary *getEntryTypes() {
 
             BOOL_INCLUDE_TAX_FIELD : tBool,
             STRING_USERNAME : tString,
-            STRING_FULLNAME : tString,
 
             STRING_CURRENCY : tString,
 
-            BOOL_INCL_CSV_HEADERS : tBool,
             STRING_DATE_SEPARATOR : tString,
             BOOL_DEFAULT_TO_FIRST_TRIP_DATE : tBool,
 
@@ -201,8 +197,8 @@ static NSDictionary *getDefaultValues() {
             STRING_DEFAULT_EMAIL_TO : @"",
             STRING_DEFAULT_EMAIL_CC : @"",
             STRING_DEFAULT_EMAIL_BCC : @"",
-            STRING_DEFAULT_EMAIL_SUBJECT : LocalizedString(@"SmartReceipts - %REPORT_NAME%", nil),
-            PDF_FOOTER_STRING : LocalizedString(@"pdf.report.default.footer.text", nil),
+            STRING_DEFAULT_EMAIL_SUBJECT : LocalizedString(@"EMAIL_DATA_SUBJECT", nil),
+            PDF_FOOTER_STRING : LocalizedString(@"pref_pro_pdf_footer_defaultValue", nil),
             BOOL_INCLUDE_CATEGORICAL_SUMMATION : @NO,
             BOOL_SEPARATE_PAYMANTS_BY_CATEGORY : @NO,
             BOOL_OMIT_DEFAULT_PDF_TABLE : @NO,
@@ -218,11 +214,9 @@ static NSDictionary *getDefaultValues() {
 
             BOOL_INCLUDE_TAX_FIELD : @NO,
             STRING_USERNAME : @"",
-            STRING_FULLNAME : @"",
 
             STRING_CURRENCY : currencyCode,
 
-            BOOL_INCL_CSV_HEADERS : @NO,
             STRING_DATE_SEPARATOR : dateSeparator,
             BOOL_DEFAULT_TO_FIRST_TRIP_DATE : @NO,
 
@@ -374,7 +368,7 @@ static NSUserDefaults* instance() {
 
 + (NSString *)pdfFooterString {
     if (![WBPreferences isPDFFooterUnlocked]) {
-        return LocalizedString(@"pdf.report.default.footer.text", nil);
+        return LocalizedString(@"pref_pro_pdf_footer_defaultValue", nil);
     }
     
     return [instance() objectForKey:PDF_FOOTER_STRING];
@@ -425,14 +419,6 @@ static NSUserDefaults* instance() {
     [instance() setObject:userID forKey:STRING_USERNAME];
 }
 
-+ (NSString*) fullName {
-    return [instance() stringForKey:STRING_FULLNAME];
-}
-
-+ (void) setFullName:(NSString*) fullName {
-    [instance() setObject:fullName forKey:STRING_FULLNAME];
-}
-
 + (int) defaultTripDuration {
     return (int)[instance() integerForKey:INT_DEFAULT_TRIP_DURATION];
 }
@@ -459,14 +445,6 @@ static NSUserDefaults* instance() {
 
 + (void) setDefaultToFirstReportDate:(BOOL) defaultToFirstReportDate {
     [instance() setBool:defaultToFirstReportDate forKey:BOOL_DEFAULT_TO_FIRST_TRIP_DATE];
-}
-
-+ (BOOL) includeCSVHeaders {
-    return [instance() boolForKey:BOOL_INCL_CSV_HEADERS];
-}
-
-+ (void) setIncludeCSVHeaders:(BOOL) includeCSVHeaders {
-    [instance() setBool:includeCSVHeaders forKey:BOOL_INCL_CSV_HEADERS];
 }
 
 + (BOOL)isTheDistancePriceBeIncludedInReports {

--- a/SmartReceipts/Reports/Generators/TripCSVGenerator.swift
+++ b/SmartReceipts/Reports/Generators/TripCSVGenerator.swift
@@ -41,7 +41,7 @@ class TripCSVGenerator: ReportCSVGenerator {
     
     private func appendReceiptsTable(_ content: NSMutableString) {
         let receiptTable = ReportCSVTable(content: content, columns: receiptColumns())!
-        receiptTable.includeHeaders = WBPreferences.includeCSVHeaders()
+        receiptTable.includeHeaders = true
         
         var recs = receipts()
         if WBPreferences.printDailyDistanceValues() {
@@ -55,7 +55,7 @@ class TripCSVGenerator: ReportCSVGenerator {
     private func appendCategoricalSummationTable(_ content: NSMutableString) {
         content.append(TABLE_SPACING)
         let receiptTable = ReportCSVTable(content: content, columns: categoryColumns())!
-        receiptTable.includeHeaders = WBPreferences.includeCSVHeaders()
+        receiptTable.includeHeaders = true
         let receipts = receiptsByCategories()
         receiptTable.append(withRows: Array(receipts.values))
     }
@@ -64,7 +64,7 @@ class TripCSVGenerator: ReportCSVGenerator {
         let categoryReceipts = receiptsByCategories()
         for (category, receipts) in categoryReceipts {
             let receiptTable = ReportCSVTable(content: content, columns: receiptColumns())!
-            receiptTable.includeHeaders = WBPreferences.includeCSVHeaders()
+            receiptTable.includeHeaders = true
             content.append(TABLE_SPACING)
             content.append(category + "\n")
             receiptTable.append(withRows: receipts)
@@ -76,7 +76,7 @@ class TripCSVGenerator: ReportCSVGenerator {
         let dists = distances()
         if dists.isEmpty { return }
         let receiptTable = ReportCSVTable(content: content, columns: distanceColumns())!
-        receiptTable.includeHeaders = WBPreferences.includeCSVHeaders()
+        receiptTable.includeHeaders = true
         receiptTable.append(withRows: dists)
     }
 }

--- a/SmartReceipts/Reports/Tables/ReportTable.m
+++ b/SmartReceipts/Reports/Tables/ReportTable.m
@@ -19,6 +19,7 @@
 
 - (instancetype)initWithColumns:(NSArray *)columns {
     self = [super init];
+    self.includeHeaders = true;
     if (self) {
         _columns = columns;
     }

--- a/SmartReceipts/Supporting Files/en.lproj/Localizable.strings
+++ b/SmartReceipts/Supporting Files/en.lproj/Localizable.strings
@@ -182,14 +182,6 @@
 "settings.purchase.section.title" = "Purchases";
 "settings.purchase.subscription.valid.until.label.base" = "Valid until: %@";
 "settings.receipt.assume.full.page.image.label" = "Assume Full Page Receipt Image";
-"pref_privacy_header" = "Privacy";
-"pref_about_privacy_policy_title" = "Privacy Policy";
-"pref_privacy_enable_analytics_title" = "Share Analytics";
-"pref_privacy_enable_analytics_summary" = "With Google/Firebase Analytics";
-"pref_privacy_enable_crash_tracking_title" = "Share Crash Information";
-"pref_privacy_enable_crash_tracking_summary" = "With Google Crashlytics";
-"pref_privacy_enable_ad_personalization_title" = "Allow Ad Personalization";
-"pref_privacy_enable_ad_personalization_summary" = "With Google AdMob";
 
 "trips.controller.daily.total" = "Daily Total: %@";
 "trips.controller.distance.total" = "Distance Total: %@";


### PR DESCRIPTION
This includes the following changes:

1. Applied the majority of our Android translations to the iOS settings page
2. Removed the 'Full Name' setting that is unused
3. Removed the 'CSV Headers' setting, keeping this always on by default
4. Added support for email separation by semi-colon (same as Android)