### PR TITLE
Reverted to an older OS version for Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: objective-c
 osx_image: xcode10
 xcode_workspace: SmartReceipts.xcworkspace
 xcode_scheme: SmartReceipts
-xcode_destination: platform=iOS Simulator,OS=12.0,name=iPhone X
+xcode_destination: platform=iOS Simulator,OS=11.3,name=iPhone X
 notifications:
   email:
     recipients:


### PR DESCRIPTION
There seems to be bootstrapping issues with the 12.0 version

```
Error Domain=IDETestOperationsObserverErrorDomain Code=6 "Early unexpected exit, operation never finished bootstrapping - no restart will be attempted" UserInfo={NSLocalizedDescription=Early unexpected exit, operation never finished bootstrapping - no restart will be attempted, NSUnderlyingError=0x7fbc2f593cb0 {Error Domain=IDETestOperationsObserverErrorDomain Code=5 "Test runner exited before starting test execution." UserInfo={NSLocalizedDescription=Test runner exited before starting test execution., NSLocalizedRecoverySuggestion=If you believe this error represents a bug, please attach the result bundle at /Users/travis/Library/Developer/Xcode/DerivedData/SmartReceipts-bwdjalohqtahoocaqizrcxwrszmx/Logs/Test/Run-SmartReceipts-2018.10.20_15-31-24-+0000.xcresult}}}
```