### PR TITLE
Added support for system string translations

### DIFF
--- a/SmartReceipts/AppDelegate.swift
+++ b/SmartReceipts/AppDelegate.swift
@@ -133,13 +133,13 @@ extension AppDelegate {
             let alert = UIAlertController(title: LocalizedString("receipt_attach_file"),
                 message: String(format: LocalizedString("dialog_attachment_text"), LocalizedString("image")), preferredStyle: .alert)
             
-            alert.addAction(UIAlertAction(title: LocalizedString("generic.button.title.ok"), style: .cancel, handler: nil))
+            alert.addAction(UIAlertAction(title: LocalizedString("generic_button_title_ok"), style: .cancel, handler: nil))
             AdNavigationEntryPoint.navigationController?.visibleViewController?.present(alert, animated: true)
         } else {
             let alert = UIAlertController(title: LocalizedString("receipt_attach_file"),
                 message: String(format: LocalizedString("dialog_attachment_text"), LocalizedString("pdf")), preferredStyle: .alert)
             
-            alert.addAction(UIAlertAction(title: LocalizedString("generic.button.title.ok"), style: .cancel, handler: nil))
+            alert.addAction(UIAlertAction(title: LocalizedString("generic_button_title_ok"), style: .cancel, handler: nil))
             AdNavigationEntryPoint.navigationController?.visibleViewController?.present(alert, animated: true)
         }
     }

--- a/SmartReceipts/Common/UI/Eureka Custom Cells/ExchangeRateCell.swift
+++ b/SmartReceipts/Common/UI/Eureka Custom Cells/ExchangeRateCell.swift
@@ -113,7 +113,7 @@ public class ExchangeRateCell: DecimalCell {
     private func showUnsupportedCurrrencyInfo() {
         alertPresenter?.presentAlert(LocalizedString("exchange.rate.error.unsupported.currency.title"),
                             message: LocalizedString("exchange.rate.error.unsupported.currency.message"),
-                      dismissButton: LocalizedString("generic.button.title.ok"))
+                      dismissButton: LocalizedString("generic_button_title_ok"))
     }
     
     private func openSettings() {

--- a/SmartReceipts/Extensions/UIAlert+Extensions.swift
+++ b/SmartReceipts/Extensions/UIAlert+Extensions.swift
@@ -13,7 +13,7 @@ extension UIAlertController {
     static func showInfo(text: String, on: UIViewController? = nil) -> Observable<Void> {
         let controller = UIAlertController(title: "", message: text, preferredStyle: .alert)
         let result = Observable<Void>.create { observer -> Disposable in
-            let action = UIAlertAction(title: LocalizedString("generic.button.title.ok"), style: .default, handler: { _ in
+            let action = UIAlertAction(title: LocalizedString("generic_button_title_ok"), style: .default, handler: { _ in
                 observer.onNext(())
                 observer.onCompleted()
             })

--- a/SmartReceipts/Extensions/Viperit+Extensions.swift
+++ b/SmartReceipts/Extensions/Viperit+Extensions.swift
@@ -24,7 +24,7 @@ extension Presenter {
 extension Router {
     func openAlert(title: String?, message: String) {
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: LocalizedString("generic.button.title.ok"), style: .cancel, handler: nil))
+        alert.addAction(UIAlertAction(title: LocalizedString("generic_button_title_ok"), style: .cancel, handler: nil))
         _view.present(alert, animated: true, completion: nil)
     }
     

--- a/SmartReceipts/Models/PaymentMethod.swift
+++ b/SmartReceipts/Models/PaymentMethod.swift
@@ -8,6 +8,9 @@
 
 import FMDB
 
+// For legacy reasons from before we started supporting translations, we use this as the default fallback option
+fileprivate let LEGACY_DEFAULT_PAYMENT_METHOD = "Unspecified"
+
 @objcMembers
 class PaymentMethod: NSObject, FetchedModel, Pickable {
     var objectId: UInt = 0
@@ -53,8 +56,7 @@ class PaymentMethod: NSObject, FetchedModel, Pickable {
         for method in allMethods! {
             if method.method == LocalizedString("payment_method_unspecified", comment: "") {
                 return method
-            } else if method.method == "Unspecified" {
-                // For legacy reasons from before we started supporting translations, we use this as the default fallback option
+            } else if method.method == LEGACY_DEFAULT_PAYMENT_METHOD {
                 return method
             }
         }

--- a/SmartReceipts/Models/PaymentMethod.swift
+++ b/SmartReceipts/Models/PaymentMethod.swift
@@ -51,7 +51,10 @@ class PaymentMethod: NSObject, FetchedModel, Pickable {
     class func defaultMethod(_ database: Database = Database.sharedInstance()) -> PaymentMethod {
         let allMethods = database.allPaymentMethods()
         for method in allMethods! {
-            if method.method == LocalizedString("payment.method.unspecified", comment: "") {
+            if method.method == LocalizedString("payment_method_unspecified", comment: "") {
+                return method
+            } else if method.method == "Unspecified" {
+                // For legacy reasons from before we started supporting translations, we use this as the default fallback option
                 return method
             }
         }

--- a/SmartReceipts/Modules/Auth/AuthView.swift
+++ b/SmartReceipts/Modules/Auth/AuthView.swift
@@ -133,7 +133,7 @@ extension AuthView: AuthViewInterface {
             switch event {
             case .next(let errorMessage):
                 let alert = UIAlertController(title: LocalizedString("login.error.title"), message: errorMessage, preferredStyle: .alert)
-                let action = UIAlertAction(title: LocalizedString("generic.button.title.ok"), style: .cancel, handler: nil)
+                let action = UIAlertAction(title: LocalizedString("generic_button_title_ok"), style: .cancel, handler: nil)
                 alert.addAction(action)
                 self?.present(alert, animated: true, completion: nil)
             default: break

--- a/SmartReceipts/Modules/Backup/BackupView.swift
+++ b/SmartReceipts/Modules/Backup/BackupView.swift
@@ -271,7 +271,7 @@ extension BackupView {
                         self.showOptions(file: fileUrl)
                     } else {
                         Logger.error("Failed to properly export data")
-                        self.presenter._router.openAlert(title: LocalizedString("generic.error.alert.title"),
+                        self.presenter._router.openAlert(title: LocalizedString("generic_error_alert_title"),
                                                        message: LocalizedString("EXPORT_ERROR"))
                     }
                 }

--- a/SmartReceipts/Modules/Edit Distance/EditDistanceView.swift
+++ b/SmartReceipts/Modules/Edit Distance/EditDistanceView.swift
@@ -49,7 +49,7 @@ final class EditDistanceView: UserInterface {
         } else {
             let title = LocalizedString("edit.distance.controller.validation.error.title")
             let alert = UIAlertController(title: title, message: errorsDescription, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: LocalizedString("generic.button.title.ok"), style: .cancel, handler: nil))
+            alert.addAction(UIAlertAction(title: LocalizedString("generic_button_title_ok"), style: .cancel, handler: nil))
             present(alert, animated: true, completion: nil)
         }
     }

--- a/SmartReceipts/Modules/Edit Trip/EditTripInteractor.swift
+++ b/SmartReceipts/Modules/Edit Trip/EditTripInteractor.swift
@@ -34,7 +34,7 @@ class EditTripInteractor: Interactor {
         } else {
             let action = update ? "update" : "insert"
             Logger.error("Can't \(action) report: \(trip.description)")
-            presenter.presentAlert(title: LocalizedString("generic.error.alert.title"),
+            presenter.presentAlert(title: LocalizedString("generic_error_alert_title"),
                                  message: LocalizedString("toast_error_trip_exists"))
         }
     }

--- a/SmartReceipts/Modules/Generate Report/GenerateReportInteractor.swift
+++ b/SmartReceipts/Modules/Generate Report/GenerateReportInteractor.swift
@@ -138,7 +138,7 @@ class GenerateReportInteractor: Interactor {
                 case .zipImagesFailed:
                     message = LocalizedString("DIALOG_EMAIL_CHECKBOX_ZIP_WITH_METADATA")
                 }
-                actions.append(UIAlertAction(title: LocalizedString("generic.button.title.ok"), style: .default, handler: nil))
+                actions.append(UIAlertAction(title: LocalizedString("generic_button_title_ok"), style: .default, handler: nil))
                 self.presenter.presentSheet(title: title, message: message, actions: actions)
             })
         }
@@ -146,7 +146,7 @@ class GenerateReportInteractor: Interactor {
     
     func validateSelection() -> Bool {
         if (!fullPdfReport.value && !pdfReportWithoutTable.value && !csvFile.value && !zipStampedJPGs.value) {
-            presenter.presentAlert(title: LocalizedString("generic.error.alert.title"),
+            presenter.presentAlert(title: LocalizedString("generic_error_alert_title"),
                                    message: LocalizedString("DIALOG_EMAIL_TOAST_NO_SELECTION"))
             return false
         }

--- a/SmartReceipts/Persistence/Helpers/Database+PaymentMethods.m
+++ b/SmartReceipts/Persistence/Helpers/Database+PaymentMethods.m
@@ -31,7 +31,7 @@
             && [self insertPaymentMethodWithName:LocalizedString(@"payment_method_default_check", nil)]
             && [self insertPaymentMethodWithName:LocalizedString(@"payment_method_default_personal_card", nil)]
             && [self insertPaymentMethodWithName:LocalizedString(@"payment_method_default_corporate_card", nil)]
-            && [self insertPaymentMethodWithName:LocalizedString(@"payment.method.unspecified", nil)];
+            && [self insertPaymentMethodWithName:LocalizedString(@"payment_method_unspecified", nil)];
 }
 
 - (BOOL)insertPaymentMethodWithName:(NSString *)methodName {

--- a/SmartReceipts/Supporting Files/de.lproj/Localizable.strings
+++ b/SmartReceipts/Supporting Files/de.lproj/Localizable.strings
@@ -1,7 +1,7 @@
 /** Android System Strings (ok, untitled, error_message_title) **/
 "generic_button_title_ok" = "OK";
 "generic_error_alert_title" = "Fehler";
-"payment_method_unspecified" = "<Unbenannt>;
+"payment_method_unspecified" = "<Unbenannt>";
 
 
 /** Legacy Android Strings (i.e. Ones that no longer existing on the master branch) **/

--- a/SmartReceipts/Supporting Files/de.lproj/Localizable.strings
+++ b/SmartReceipts/Supporting Files/de.lproj/Localizable.strings
@@ -1,3 +1,9 @@
+/** Android System Strings (ok, untitled, error_message_title) **/
+"generic_button_title_ok" = "OK";
+"generic_error_alert_title" = "Fehler";
+"payment_method_unspecified" = "<Unbenannt>;
+
+
 /** Legacy Android Strings (i.e. Ones that no longer existing on the master branch) **/
 "receipt_dialog_action_camera" = "Belegbild machen";
 "receipt_dialog_action_swap_up" = "tauschen oben";

--- a/SmartReceipts/Supporting Files/en.lproj/Localizable.strings
+++ b/SmartReceipts/Supporting Files/en.lproj/Localizable.strings
@@ -25,6 +25,12 @@
 "receipt_file_picker_cant_import_error" = "Can't import selected file";
 "drive_sync_error_unknown" = "Unknown Error";
 
+/** Android System Strings (ok, untitled, error_message_title) **/
+/** <MARKER - SECTION COMPLETE> **/
+"generic_button_title_ok" = "OK";
+"generic_error_alert_title" = "Error";
+"payment_method_unspecified" = "<Untitled>";
+
 /** Legacy Android Strings (i.e. Ones that no longer existing on the master branch) **/
 /** <MARKER - SECTION COMPLETE> **/
 "receipt_dialog_action_camera" = "Take Receipt Image";
@@ -32,14 +38,9 @@
 "receipt_dialog_action_swap_down" = "Swap Down";
 "action_send_attach" = "Attach %@ to Receipt";
 "action_send_replace" = "Replace Receipt %@";
+
 "pref_layout_display_photo_title" = "Include Picture/PDF Marker";
 "pref_layout_display_photo_summary" = "Indicate if values have a photo/PDF";
-
-
-/** Android System Strings (e.g. okay) **/
-"generic.button.title.ok" = "OK";
-"generic.error.alert.title" = "Error";
-"payment.method.unspecified" = "Unspecified";
 
 
 /** iOS Strings that slightly differ from Android and can be replaced with similar Android ones **/

--- a/SmartReceipts/Supporting Files/es.lproj/Localizable.strings
+++ b/SmartReceipts/Supporting Files/es.lproj/Localizable.strings
@@ -1,7 +1,7 @@
 /** Android System Strings (ok, untitled, error_message_title) **/
 "generic_button_title_ok" = "Aceptar";
 "generic_error_alert_title" = "Error";
-"payment_method_unspecified" = "<Sin título>;
+"payment_method_unspecified" = "<Sin título>";
 
 
 /** Legacy Android Strings (i.e. Ones that no longer existing on the master branch) **/

--- a/SmartReceipts/Supporting Files/es.lproj/Localizable.strings
+++ b/SmartReceipts/Supporting Files/es.lproj/Localizable.strings
@@ -1,3 +1,10 @@
+/** Android System Strings (ok, untitled, error_message_title) **/
+"generic_button_title_ok" = "Aceptar";
+"generic_error_alert_title" = "Error";
+"payment_method_unspecified" = "<Sin título>;
+
+
+/** Legacy Android Strings (i.e. Ones that no longer existing on the master branch) **/
 "receipt_dialog_action_camera" = "Tomar imagen del recibo";
 "receipt_dialog_action_swap_up" = "Intercambiar arriba";
 "receipt_dialog_action_swap_down" = "Intercambiar abajo";

--- a/SmartReceipts/Supporting Files/fr.lproj/Localizable.strings
+++ b/SmartReceipts/Supporting Files/fr.lproj/Localizable.strings
@@ -1,3 +1,9 @@
+/** Android System Strings (ok, untitled, error_message_title) **/
+"generic_button_title_ok" = "OK";
+"generic_error_alert_title" = "Erreur";
+"payment_method_unspecified" = "<Sans nom>";
+
+
 /** Legacy Android Strings (i.e. Ones that no longer existing on the master branch) **/
 "receipt_dialog_action_camera" = "Prendre la photo du reçu";
 "receipt_dialog_action_swap_up" = "Déplacer vers le haut";

--- a/SmartReceipts/Supporting Files/iw.lproj/Localizable.strings
+++ b/SmartReceipts/Supporting Files/iw.lproj/Localizable.strings
@@ -1,3 +1,16 @@
-/* 
-  TODO
-*/
+/** Android System Strings (ok, untitled, error_message_title) **/
+"generic_button_title_ok" = "אישור";
+"generic_error_alert_title" = "שגיאה";
+"payment_method_unspecified" = "‏>ללא כותרת<;
+
+
+/** Legacy Android Strings (i.e. Ones that no longer existing on the master branch) **/
+// TODO: Translate each of these items
+"receipt_dialog_action_camera" = "Take Receipt Image";
+"receipt_dialog_action_swap_up" = "Swap Up";
+"receipt_dialog_action_swap_down" = "Swap Down";
+"action_send_attach" = "Attach %@ to Receipt";
+"action_send_replace" = "Replace Receipt %@";
+
+"pref_layout_display_photo_title" = "Include Picture/PDF Marker";
+"pref_layout_display_photo_summary" = "Indicate if values have a photo/PDF";

--- a/SmartReceipts/Supporting Files/iw.lproj/Localizable.strings
+++ b/SmartReceipts/Supporting Files/iw.lproj/Localizable.strings
@@ -1,7 +1,7 @@
 /** Android System Strings (ok, untitled, error_message_title) **/
 "generic_button_title_ok" = "אישור";
 "generic_error_alert_title" = "שגיאה";
-"payment_method_unspecified" = "‏>ללא כותרת<;
+"payment_method_unspecified" = "‏ללא כותרת";
 
 
 /** Legacy Android Strings (i.e. Ones that no longer existing on the master branch) **/

--- a/SmartReceipts/Supporting Files/pt.lproj/Localizable.strings
+++ b/SmartReceipts/Supporting Files/pt.lproj/Localizable.strings
@@ -1,3 +1,9 @@
+/** Android System Strings (ok, untitled, error_message_title) **/
+"generic_button_title_ok" = "OK";
+"generic_error_alert_title" = "Erro";
+"payment_method_unspecified" = "<Sem título>;
+
+
 /** Legacy Android Strings (i.e. Ones that no longer existing on the master branch) **/
 "receipt_dialog_action_camera" = "Tirar foto do recibo";
 "receipt_dialog_action_swap_up" = "Swap para cima";

--- a/SmartReceipts/Supporting Files/pt.lproj/Localizable.strings
+++ b/SmartReceipts/Supporting Files/pt.lproj/Localizable.strings
@@ -1,7 +1,7 @@
 /** Android System Strings (ok, untitled, error_message_title) **/
 "generic_button_title_ok" = "OK";
 "generic_error_alert_title" = "Erro";
-"payment_method_unspecified" = "<Sem título>;
+"payment_method_unspecified" = "<Sem título>";
 
 
 /** Legacy Android Strings (i.e. Ones that no longer existing on the master branch) **/

--- a/SmartReceipts/Supporting Files/ru.lproj/Localizable.strings
+++ b/SmartReceipts/Supporting Files/ru.lproj/Localizable.strings
@@ -1,3 +1,9 @@
+/** Android System Strings (ok, untitled, error_message_title) **/
+"generic_button_title_ok" = "ОК";
+"generic_error_alert_title" = "Ошибка";
+"payment_method_unspecified" = "<Без названия>;
+
+
 /** Legacy Android Strings (i.e. Ones that no longer existing on the master branch) **/
 "receipt_dialog_action_camera" = "Сделать снимок чека";
 "receipt_dialog_action_swap_up" = "Поменять местами с верхним";

--- a/SmartReceipts/Supporting Files/ru.lproj/Localizable.strings
+++ b/SmartReceipts/Supporting Files/ru.lproj/Localizable.strings
@@ -1,7 +1,7 @@
 /** Android System Strings (ok, untitled, error_message_title) **/
 "generic_button_title_ok" = "ОК";
 "generic_error_alert_title" = "Ошибка";
-"payment_method_unspecified" = "<Без названия>;
+"payment_method_unspecified" = "<Без названия>";
 
 
 /** Legacy Android Strings (i.e. Ones that no longer existing on the master branch) **/

--- a/SmartReceipts/Supporting Files/uk.lproj/Localizable.strings
+++ b/SmartReceipts/Supporting Files/uk.lproj/Localizable.strings
@@ -1,3 +1,9 @@
+/** Android System Strings (ok, untitled, error_message_title) **/
+"generic_button_title_ok" = "OK";
+"generic_error_alert_title" = "Помилка";
+"payment_method_unspecified" = "<Без назви>";
+
+
 /** Legacy Android Strings (i.e. Ones that no longer existing on the master branch) **/
 "receipt_dialog_action_camera" = "Зробити знімок чека";
 "receipt_dialog_action_swap_up" = "Поміняти місцями з верхнім";

--- a/SmartReceipts/ViewControllers/QuickAlertPresenter.swift
+++ b/SmartReceipts/ViewControllers/QuickAlertPresenter.swift
@@ -15,7 +15,7 @@ protocol QuickAlertPresenter: class {
 }
 
 extension QuickAlertPresenter where Self: UIViewController {
-    func presentAlert(_ title: String?, message: String, dismissButton: String = LocalizedString("generic.button.title.ok", comment: "")) {
+    func presentAlert(_ title: String?, message: String, dismissButton: String = LocalizedString("generic_button_title_ok", comment: "")) {
         let dismissAction = UIAlertAction(title: dismissButton, style: .default, handler: nil)
         presentAlert(title, message: message, actions: [dismissAction])
     }

--- a/SmartReceiptsTests/Model/PaymentMethodTests.swift
+++ b/SmartReceiptsTests/Model/PaymentMethodTests.swift
@@ -30,7 +30,7 @@ class PaymentMethodTests: SmartReceiptsTestsBase {
     }
     
     func testEqualPaymentMethod() {
-        let unspecifiedMethodName = "Unspecified"
+        let unspecifiedMethodName = LocalizedString("payment_method_unspecified", comment: "")
         XCTAssertTrue(paymentMethod.method == unspecifiedMethodName)
         
         let unspecifiedMethod = PaymentMethod(objectId: 100, method: unspecifiedMethodName)


### PR DESCRIPTION
These specifically include the addition of the following Android strings:
 - android.R.string.ok
 - android.R.string.error_message_title
 - android.R.string.untitled

Which have been mapped to our iOS Localization file to support tracking for each.