### PR TITLE
Added a fallback language support to English

### DIFF
--- a/SmartReceipts/Common/Constants/Global.swift
+++ b/SmartReceipts/Common/Constants/Global.swift
@@ -33,9 +33,24 @@ func delayedExecution(_ afterSecons: TimeInterval, closure: @escaping () -> ()) 
 }
 
 func LocalizedString(_ key: String, comment: String = "") -> String {
-    var result = NSLocalizedString(key, tableName: nil, comment: comment)
+    // By default, attempt to load from our Shared set of strings
+    var result = NSLocalizedString(key, tableName: "SharedLocalizable", comment: comment)
     if result == key {
-        result = NSLocalizedString(key, tableName: "SharedLocalizable", comment: comment)
+        // If we failed to find this string in our SharedLocalizable.strings file, check Localizable.strings one
+        result = NSLocalizedString(key, tableName: nil, comment: comment)
+    }
+    if result == key {
+        // If we cannot find it in either, fall back to English
+        if let path = Bundle.main.path(forResource: "en", ofType: "lproj") {
+            if let enBundle = Bundle(path: path) {
+                // Check the English Localizable.strings file
+                result = NSLocalizedString(key, bundle: enBundle, comment: comment)
+                if result == key {
+                    // And finally fall back to the English SharedLocalizable.strings file
+                    result = NSLocalizedString(key, tableName: "SharedLocalizable", bundle: enBundle, comment: comment)
+                }
+            }
+        }
     }
     return result
 }

--- a/SmartReceipts/Common/Constants/Global.swift
+++ b/SmartReceipts/Common/Constants/Global.swift
@@ -40,6 +40,7 @@ func LocalizedString(_ key: String, comment: String = "") -> String {
         result = NSLocalizedString(key, tableName: nil, comment: comment)
     }
     if result == key {
+        Logger.debug("Unknown String Key: \(key). Falling back to the English variant")
         // If we cannot find it in either, fall back to English
         if let path = Bundle.main.path(forResource: "en", ofType: "lproj") {
             if let enBundle = Bundle(path: path) {

--- a/SmartReceipts/Common/Localization/LocalizedString.m
+++ b/SmartReceipts/Common/Localization/LocalizedString.m
@@ -11,9 +11,26 @@
 @implementation LocalizedString
 
 + (NSString*)from:(NSString *)key comment:(NSString *)comment {
-    NSString* result = NSLocalizedString(key, comment);
+    // By default, attempt to load from our Shared set of strings
+    NSString* result = NSLocalizedStringFromTable(key, @"SharedLocalizable", comment);
     if ([result isEqualToString:key]) {
-        result = NSLocalizedStringFromTable(key, @"SharedLocalizable", comment);
+        // If we failed to find this string in our SharedLocalizable.strings file, check Localizable.strings one
+        result = NSLocalizedString(key, comment);
+    }
+    if ([result isEqualToString:key]) {
+        // If we cannot find it in either, fall back to English
+        NSString* path = [[NSBundle mainBundle] pathForResource:@"en" ofType:@"lproj"];
+        if (path) {
+            NSBundle* enBundle = [NSBundle bundleWithPath:path];
+            if (enBundle) {
+                // Check the English Localizable.strings file
+                result = [enBundle localizedStringForKey:key value:@"" table:nil];
+                if ([result isEqualToString:key]) {
+                    // If we failed to find this string in our SharedLocalizable.strings file, check Localizable.strings one
+                    result = [enBundle localizedStringForKey:key value:@"" table:@"SharedLocalizable"];
+                }
+            }
+        }
     }
     return result;
 }


### PR DESCRIPTION
By default, iOS will return the key value rather than a defined translation. To simplify things for our users, I've added support for a default fallback mechansim to the english bundle.