### PR TITLE
Removed an iOS settings that lacks an Android equivalent

### DIFF
--- a/SmartReceipts/Modules/Edit Receipt/EditReceiptInteractor.swift
+++ b/SmartReceipts/Modules/Edit Receipt/EditReceiptInteractor.swift
@@ -111,7 +111,6 @@ class EditReceiptInteractor: Interactor {
     
     private func validateDate(in receipt: WBReceipt) {
         Observable<Void>.just(())
-            .filter({ !WBPreferences.allowDataEntryOutsideTripBounds() })
             .filter({ receipt.date > receipt.trip.endDate || receipt.date < receipt.trip.startDate })
             .subscribe(onNext: {
                 let message = LocalizedString("DIALOG_RECEIPTMENU_TOAST_BAD_DATE")

--- a/SmartReceipts/Modules/Settings/SettingsFormView.swift
+++ b/SmartReceipts/Modules/Settings/SettingsFormView.swift
@@ -192,12 +192,6 @@ class SettingsFormView: FormViewController {
         }).cellSetup({ cell, _ in
             cell.textLabel?.numberOfLines = 3
         })
-        
-        <<< switchRow(LocalizedString("settings.allow.data.outside.trip.bounds.label"),
-            value: WBPreferences.allowDataEntryOutsideTripBounds())
-        .onChange({ row in
-            WBPreferences.setAllowDataEntryOutsideTripBounds(row.value!)
-        })
             
         <<< DecimalRow() { row in
             row.title = LocalizedString("pref_receipt_minimum_receipts_price_title")

--- a/SmartReceipts/Persistence/WBPreferences.h
+++ b/SmartReceipts/Persistence/WBPreferences.h
@@ -118,9 +118,6 @@
 + (BOOL)isAutocompleteEnabled;
 + (void)setAutocompleteEnabled:(BOOL)value;
 
-+ (BOOL)allowDataEntryOutsideTripBounds;
-+ (void)setAllowDataEntryOutsideTripBounds:(BOOL)value;
-
 + (NSString *)pdfFooterString;
 + (void)setPDFFooterString:(NSString *)string;
 

--- a/SmartReceipts/Persistence/WBPreferences.m
+++ b/SmartReceipts/Persistence/WBPreferences.m
@@ -23,7 +23,6 @@ static NSString * const STRING_DEFAULT_EMAIL_CC = @"EmailCC";
 static NSString * const STRING_DEFAULT_EMAIL_BCC = @"EmailBCC";
 static NSString * const STRING_DEFAULT_EMAIL_SUBJECT = @"EmailSubject";
 static NSString * const INT_DEFAULT_TRIP_DURATION = @"TripDuration";
-static NSString * const BOOL_ALLOW_DATA_OUTSIDE_TRIP_BOUNDS = @"AllowDataOutsideTripBounds";
 static NSString * const BOOL_AUTOCOMPLETE_ENABLED = @"IsAutocompleteEnabled";
 static NSString * const STRING_USERNAME = @"UserName";
 static NSString * const BOOL_PREDICT_CATEGORIES = @"PredictCats";
@@ -107,7 +106,6 @@ static NSDictionary *getEntryTypes() {
     return @{
             INT_DEFAULT_TRIP_DURATION : tInt,
             BOOL_AUTOCOMPLETE_ENABLED : tBool,
-            BOOL_ALLOW_DATA_OUTSIDE_TRIP_BOUNDS : tBool,
             FLOAT_MIN_RECEIPT_PRICE : tFloat,
 
             STRING_DEFAULT_EMAIL_TO : tString,
@@ -191,7 +189,6 @@ static NSDictionary *getDefaultValues() {
     return @{
             INT_DEFAULT_TRIP_DURATION : @3,
             BOOL_AUTOCOMPLETE_ENABLED : @(YES),
-            BOOL_ALLOW_DATA_OUTSIDE_TRIP_BOUNDS : @(YES),
 
             FLOAT_MIN_RECEIPT_PRICE : @(MIN_FLOAT),
             STRING_DEFAULT_EMAIL_TO : @"",
@@ -606,14 +603,6 @@ static NSUserDefaults* instance() {
 
 + (void)setAutocompleteEnabled:(BOOL)value{
     [instance() setBool:value forKey:BOOL_AUTOCOMPLETE_ENABLED];
-}
-
-+ (BOOL)allowDataEntryOutsideTripBounds {
-    return [instance() boolForKey:BOOL_ALLOW_DATA_OUTSIDE_TRIP_BOUNDS];
-}
-
-+ (void)setAllowDataEntryOutsideTripBounds:(BOOL)value{
-    [instance() setBool:value forKey:BOOL_ALLOW_DATA_OUTSIDE_TRIP_BOUNDS];
 }
     
 + (BOOL)analyticsEnabled {

--- a/SmartReceipts/Supporting Files/en.lproj/Localizable.strings
+++ b/SmartReceipts/Supporting Files/en.lproj/Localizable.strings
@@ -10,7 +10,6 @@
 "receipt_import_action_sheet_title" = "Import from:";
 "receipt_import_action_files" = "Files";
 "receipt_import_action_camera_roll" = "Camera Roll";
-"settings.allow.data.outside.trip.bounds.label" = "Allow data entry outside report start/end";
 "settings.purchase.restore.label" = "Restore purchase";
 "settings.purchase.subscription.valid.until.label.base" = "Valid until: %@";
 "settings.camera.pixels.label" = "Pixels";


### PR DESCRIPTION
Rather than supporting the ability to allow or disallow showing receipts out of date bounds, matching the behavior that we have on Android.