### PR TITLE
Removed all references to @string/delete items from Android

### DIFF
--- a/SmartReceipts/Modules/Backup/BackupView.swift
+++ b/SmartReceipts/Modules/Backup/BackupView.swift
@@ -160,7 +160,7 @@ final class BackupView: UserInterface, GIDSignInUIDelegate {
         alert.addAction(UIAlertAction(title: LocalizedString("remote_backups_list_item_menu_download_images_debug"), style: .default, handler: { [unowned self] _ in
             self.presenter.downloadDebugZip(backup)
         }))
-        alert.addAction(UIAlertAction(title: LocalizedString("remote_backups_list_item_menu_delete"), style: .destructive, handler: { [unowned self] _ in
+        alert.addAction(UIAlertAction(title: LocalizedString("delete"), style: .destructive, handler: { [unowned self] _ in
             self.openDelete(backup: backup)
         }))
         alert.addAction(UIAlertAction(title: LocalizedString("DIALOG_CANCEL"), style: .cancel, handler: nil))
@@ -181,13 +181,13 @@ final class BackupView: UserInterface, GIDSignInUIDelegate {
     }
     
     private func openDelete(backup: RemoteBackupMetadata) {
-        let title = String(format: LocalizedString("dialog_remote_backup_delete_title"), backup.syncDeviceName)
+        let title = String(format: LocalizedString("delete"), backup.syncDeviceName)
         
         let isCurrent = presenter.isCurrentDevice(backup: backup)
         let format = isCurrent ? LocalizedString("dialog_remote_backup_delete_message_this_device") : LocalizedString("dialog_remote_backup_delete_message")
         let message = String(format: format, backup.syncDeviceName)
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: LocalizedString("dialog_remote_backup_delete_positive"), style: .default, handler: { [unowned self] _ in
+        alert.addAction(UIAlertAction(title: LocalizedString("delete"), style: .default, handler: { [unowned self] _ in
             self.presenter.deleteBackup(backup)
         }))
         alert.addAction(UIAlertAction(title: LocalizedString("DIALOG_CANCEL"), style: .cancel, handler: nil))

--- a/SmartReceipts/Supporting Files/de.lproj/SharedLocalizable.strings
+++ b/SmartReceipts/Supporting Files/de.lproj/SharedLocalizable.strings
@@ -513,19 +513,13 @@
 
 "remote_backups_list_item_menu_restore" = "Wiederherstellen";
 
-"remote_backups_list_item_menu_delete" = "Löschen";
-
 "remote_backups_list_item_menu_download_images" = "Auf ZIP herunterladen";
 
 "remote_backups_list_item_menu_download_images_debug" = "[Debug] herunterladen";
 
-"dialog_remote_backup_delete_title" = "Löschen";
-
 "dialog_remote_backup_delete_message" = "Sind Sie sicher, dass Sie Ihre Sicherungskopie vom %@ Gerät löschen wollen? Dieser Vorgang kann nicht rückgängig gemacht werden.";
 
 "dialog_remote_backup_delete_message_this_device" = "Sind Sie sicher, dass Sie Ihren Backup auf diesem Gerät löschen wollen? Dieser Vorgang kann nicht rückgängig gemacht werden. Bitte beachten Sie, dass Sie die automatische Sicherungen ausschalten möchte, um nach dieser Vorgang abgeschlossen ist oder alle lokalen Daten neu synchronisiert werden können.";
-
-"dialog_remote_backup_delete_positive" = "Löschen";
 
 "dialog_remote_backup_delete_progress" = "Löschen Sie Ihren Backup vom %@ Gerät …";
 

--- a/SmartReceipts/Supporting Files/en.lproj/SharedLocalizable.strings
+++ b/SmartReceipts/Supporting Files/en.lproj/SharedLocalizable.strings
@@ -510,19 +510,13 @@
 
 "remote_backups_list_item_menu_restore" = "Restore";
 
-"remote_backups_list_item_menu_delete" = "Delete";
-
 "remote_backups_list_item_menu_download_images" = "Download to ZIP";
 
 "remote_backups_list_item_menu_download_images_debug" = "[Debug] Download";
 
-"dialog_remote_backup_delete_title" = "Delete";
-
 "dialog_remote_backup_delete_message" = "Are you sure you wish to delete your backup from the %@ device? This operation cannot be undone.";
 
 "dialog_remote_backup_delete_message_this_device" = "Are you sure you wish to delete your backup of this device? This operation cannot be undone. Please note that you may wish to turn off automatic backups after this operation completes or all local data may be re-synced.";
-
-"dialog_remote_backup_delete_positive" = "Delete";
 
 "dialog_remote_backup_delete_progress" = "Deleting your backup from the %@ device…";
 

--- a/SmartReceipts/Supporting Files/es.lproj/SharedLocalizable.strings
+++ b/SmartReceipts/Supporting Files/es.lproj/SharedLocalizable.strings
@@ -513,19 +513,13 @@
 
 "remote_backups_list_item_menu_restore" = "Restaurar";
 
-"remote_backups_list_item_menu_delete" = "Eliminar";
-
 "remote_backups_list_item_menu_download_images" = "Descargar a ZIP";
 
 "remote_backups_list_item_menu_download_images_debug" = "[Depuración] Descargar";
 
-"dialog_remote_backup_delete_title" = "Eliminar";
-
 "dialog_remote_backup_delete_message" = "¿Estás seguro que deseas eliminar tu copia de seguridad del dispositivo %@? Esta operación no se puede deshacer.";
 
 "dialog_remote_backup_delete_message_this_device" = "¿Estás seguro que deseas eliminar tu copia de seguridad de este dispositivo? Esta operación no se puede deshacer. Por favor ten en cuenta que debes deshabilitar las copias de seguridad automáticas luego de terminar esta operación, o todos los datos locales pueden ser sincronizados de nuevo.";
-
-"dialog_remote_backup_delete_positive" = "Eliminar";
 
 "dialog_remote_backup_delete_progress" = "Eliminando tu copia de seguridad del dispositivo %@…";
 

--- a/SmartReceipts/Supporting Files/fr.lproj/SharedLocalizable.strings
+++ b/SmartReceipts/Supporting Files/fr.lproj/SharedLocalizable.strings
@@ -513,19 +513,13 @@
 
 "remote_backups_list_item_menu_restore" = "Restaurer";
 
-"remote_backups_list_item_menu_delete" = "Supprimer";
-
 "remote_backups_list_item_menu_download_images" = "Télécharger en ZIP";
 
 "remote_backups_list_item_menu_download_images_debug" = "[Débogage] Télécharger";
 
-"dialog_remote_backup_delete_title" = "Supprimer";
-
 "dialog_remote_backup_delete_message" = "Êtes-vous sûr de vouloir supprimer votre sauvegarde de l’appareil %@ ? Cette opération est irréversible.";
 
 "dialog_remote_backup_delete_message_this_device" = "Êtes-vous sûr de vouloir supprimer votre sauvegarde de cet appareil ? Cette opération est irréversible. Veuillez noter que vous pouvez désactiver les sauvegardes automatiques après cette opération ou toutes les données locales peuvent être resynchronisées.";
-
-"dialog_remote_backup_delete_positive" = "Supprimer";
 
 "dialog_remote_backup_delete_progress" = "Suppression de votre sauvegarde de l'appareil %@…";
 

--- a/SmartReceipts/Supporting Files/iw.lproj/SharedLocalizable.strings
+++ b/SmartReceipts/Supporting Files/iw.lproj/SharedLocalizable.strings
@@ -513,19 +513,13 @@
 
 "remote_backups_list_item_menu_restore" = "שחזר";
 
-"remote_backups_list_item_menu_delete" = "מחק";
-
 "remote_backups_list_item_menu_download_images" = "הורד כקובץ זיפ";
 
 "remote_backups_list_item_menu_download_images_debug" = "[Debug] הורד";
 
-"dialog_remote_backup_delete_title" = "מחק";
-
 "dialog_remote_backup_delete_message" = "אתה בטוח שאתה רוצה למחוק את הגיבויים שלך ממכשיר %@? פעולה זו הינה בלתי הפיכה.";
 
 "dialog_remote_backup_delete_message_this_device" = "אתה בטוח שאתה רוצה למחוק את הגיבוי שלך מהמכשיר הזה? הפעולה הינה בלתי הפיכה. אנא שים לב שרצוי לכבות את פונקציית הגיבויים האוטומטיים אחרי שהפעולה הזו הושלמה או שכל המידע המקומי עלול להיות מסונכרן שוב.";
-
-"dialog_remote_backup_delete_positive" = "מחק";
 
 "dialog_remote_backup_delete_progress" = "מחק את הגיבוי שלך ממכשיר %@ …";
 

--- a/SmartReceipts/Supporting Files/pt.lproj/SharedLocalizable.strings
+++ b/SmartReceipts/Supporting Files/pt.lproj/SharedLocalizable.strings
@@ -513,19 +513,13 @@
 
 "remote_backups_list_item_menu_restore" = "Restaurar";
 
-"remote_backups_list_item_menu_delete" = "Excluir";
-
 "remote_backups_list_item_menu_download_images" = "Baixar para ZIP";
 
 "remote_backups_list_item_menu_download_images_debug" = "[Debug] Download";
 
-"dialog_remote_backup_delete_title" = "Excluir";
-
 "dialog_remote_backup_delete_message" = "Tem certeza de que deseja excluir o backup do dispositivo %@? Essa operação não pode ser desfeita.";
 
 "dialog_remote_backup_delete_message_this_device" = "Tem certeza de que deseja excluir o backup deste dispositivo? Essa operação não pode ser desfeita. É possível desabilitar o backup automático depois que a operação for concluída, ou todos os dados locais serão sincronizados novamente.";
-
-"dialog_remote_backup_delete_positive" = "Excluir";
 
 "dialog_remote_backup_delete_progress" = "Excluindo seu backup do dispositivo %@…";
 

--- a/SmartReceipts/Supporting Files/ru.lproj/SharedLocalizable.strings
+++ b/SmartReceipts/Supporting Files/ru.lproj/SharedLocalizable.strings
@@ -513,19 +513,13 @@
 
 "remote_backups_list_item_menu_restore" = "Восстановить";
 
-"remote_backups_list_item_menu_delete" = "Удалить";
-
 "remote_backups_list_item_menu_download_images" = "Скачать в ZIP";
 
 "remote_backups_list_item_menu_download_images_debug" = "[Debug] Скачать";
 
-"dialog_remote_backup_delete_title" = "Удалить";
-
 "dialog_remote_backup_delete_message" = "Вы уверены, что хотите удалить резервную копию с устройства %@? Эта операция не может быть отменена.";
 
 "dialog_remote_backup_delete_message_this_device" = "Вы уверены, что хотите удалить резервную копию с этого устройства? Эта операция не сможет быть отменена. Пожалуйста, обратите внимание, что вы можете отключить автоматическое резервное копирование после того, как эта операция завершится, или все локальные данные могут быть повторно синхронизированы.";
-
-"dialog_remote_backup_delete_positive" = "Удалить";
 
 "dialog_remote_backup_delete_progress" = "Удаление резервной копии с устройства %@…";
 

--- a/SmartReceipts/Supporting Files/uk.lproj/SharedLocalizable.strings
+++ b/SmartReceipts/Supporting Files/uk.lproj/SharedLocalizable.strings
@@ -513,19 +513,13 @@
 
 "remote_backups_list_item_menu_restore" = "Відновити";
 
-"remote_backups_list_item_menu_delete" = "Видалити";
-
 "remote_backups_list_item_menu_download_images" = "Скачати в ZIP";
 
 "remote_backups_list_item_menu_download_images_debug" = "[Debug] Скачати";
 
-"dialog_remote_backup_delete_title" = "Видалити";
-
 "dialog_remote_backup_delete_message" = "Ви впевнені, що хочете видалити резервну копію з пристрою %@? Ця операція не може бути скасована.";
 
 "dialog_remote_backup_delete_message_this_device" = "Ви впевнені, що хочете видалити резервну копію з цього пристрою? Ця операція не зможе бути скасована. Будь ласка, зверніть увагу, що ви можете відключити автоматичне резервне копіювання після того, як ця операція завершиться, або всі локальні дані можуть бути повторно синхронізовані.";
-
-"dialog_remote_backup_delete_positive" = "Видалити";
 
 "dialog_remote_backup_delete_progress" = "Видалення резервної копії з пристрою %@…";
 


### PR DESCRIPTION
For each of these items, they have copied over the @string/delete text from Android. Since this is a manual process (and twine does not plan to support this), I simply removed each in favor of the main "delete" string.