### PR TITLE
Dev 1.16(2)

### DIFF
--- a/SmartReceipts/Common/UI/Eureka Custom Cells/PredectiveTextCell.swift
+++ b/SmartReceipts/Common/UI/Eureka Custom Cells/PredectiveTextCell.swift
@@ -33,6 +33,8 @@ public class PredectiveTextCell: TextCell, AutocompleteHelperDelegate {
     public override func textFieldDidBeginEditing(_ textField: UITextField) {
         super.textFieldDidBeginEditing(textField)
         autocompleteHelper?.textFieldDidBeginEditing(textField)
+        autocompleteHelper?.textField(textField, shouldChangeCharactersIn: .init(location: 0, length: 0), replacementString: "")
+        
     }
     
     public override func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {

--- a/SmartReceipts/Common/Utils/ReportAssetsGenerator.swift
+++ b/SmartReceipts/Common/Utils/ReportAssetsGenerator.swift
@@ -112,6 +112,7 @@ class ReportAssetsGenerator: NSObject {
     
     private func reportUrls() -> [URL] {
         let urls = receipts()
+            .filter { $0.hasFile(for: trip) }
             .compactMap { $0.imageFilePath(for: trip) }
             .map { URL(fileURLWithPath: $0) }
         

--- a/SmartReceipts/Extensions/DateFormatter+Extensions.swift
+++ b/SmartReceipts/Extensions/DateFormatter+Extensions.swift
@@ -28,4 +28,8 @@ extension DateFormatter {
         formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX"
         return formatter
     }()
+    
+    func addWeekdayFormat() {
+        dateFormat = "EEE, " + dateFormat
+    }
 }

--- a/SmartReceipts/Extensions/UIViewController+NavigationBar.swift
+++ b/SmartReceipts/Extensions/UIViewController+NavigationBar.swift
@@ -14,16 +14,22 @@ extension UIViewController {
         titleLabel.textAlignment = .center
         titleLabel.textColor = color
         titleLabel.text = title
+        titleLabel.sizeToFit()
         
         let subtitleLabel = UILabel(frame: .zero)
         subtitleLabel.font = .systemFont(ofSize: 14)
         subtitleLabel.textAlignment = .center
         subtitleLabel.textColor = color
         subtitleLabel.text = subtitle
+        subtitleLabel.sizeToFit()
         
         let stackView = UIStackView(arrangedSubviews: [titleLabel, subtitleLabel])
         stackView.alignment = .center
         stackView.axis = .vertical
+        
+        let width = max(titleLabel.bounds.width, subtitleLabel.bounds.width)
+        let height = titleLabel.bounds.height + subtitleLabel.bounds.height
+        stackView.frame.size = .init(width: width, height: height)
         
         navigationItem.titleView = stackView
     }

--- a/SmartReceipts/Models/WBReceipt.m
+++ b/SmartReceipts/Models/WBReceipt.m
@@ -138,7 +138,7 @@ static NSString* checkNoData(NSString* str) {
 }
 
 -(NSString*)imageFilePathForTrip:(WBTrip*)trip {
-    if (!_fileName) {
+    if (!checkNoData(_fileName)) {
         return nil;
     }
     return [[trip directoryPath] stringByAppendingPathComponent:_fileName];

--- a/SmartReceipts/Modules/Edit Distance/EditDistanceFormView.swift
+++ b/SmartReceipts/Modules/Edit Distance/EditDistanceFormView.swift
@@ -30,7 +30,7 @@ class EditDistanceFormView: FormViewController {
             changedDistance?.location = ""
             
             let date = ReceiptsView.sharedInputCache[SREditDistanceDateCacheKey]
-            changedDistance?.date = date ?? trip.startDate
+            changedDistance?.date = date ?? (WBPreferences.defaultToFirstReportDate() ? trip.startDate : Date())
             changedDistance?.timeZone = TimeZone.current
             
             let amount = NSDecimalNumber(value: WBPreferences.distanceRateDefaultValue())

--- a/SmartReceipts/Modules/Edit Distance/EditDistanceFormView.swift
+++ b/SmartReceipts/Modules/Edit Distance/EditDistanceFormView.swift
@@ -104,6 +104,7 @@ class EditDistanceFormView: FormViewController {
             row.title = LocalizedString("distance_date_field")
             row.value = self.changedDistance?.date
             row.dateFormatter?.timeZone = self.changedDistance?.timeZone
+            row.dateFormatter?.addWeekdayFormat()
         }.onChange({ [weak self] row in
             self?.changedDistance?.date = row.value
             ReceiptsView.sharedInputCache[SREditDistanceDateCacheKey] = row.value

--- a/SmartReceipts/Modules/Edit Receipt/EditReceiptFormView.swift
+++ b/SmartReceipts/Modules/Edit Receipt/EditReceiptFormView.swift
@@ -47,7 +47,7 @@ class EditReceiptFormView: FormViewController, QuickAlertPresenter {
         if isNewReceipt {
             self.receipt = WBReceipt()
             self.receipt.setPrice(.zero, currency: trip.defaultCurrency.code)
-            self.receipt.date = Date()
+            self.receipt.date = WBPreferences.defaultToFirstReportDate() ? trip.startDate : Date()
             self.receipt.category =  Database.sharedInstance().category(byName: proposedCategory())
             self.receipt.exchangeRate = .zero
             self.receipt.isReimbursable = WBPreferences.expensableDefault()

--- a/SmartReceipts/Modules/Edit Receipt/EditReceiptFormView.swift
+++ b/SmartReceipts/Modules/Edit Receipt/EditReceiptFormView.swift
@@ -244,6 +244,7 @@ class EditReceiptFormView: FormViewController, QuickAlertPresenter {
             row.title = LocalizedString("DIALOG_RECEIPTMENU_HINT_DATE")
             row.value = self.receipt.date
             row.dateFormatter?.timeZone = self.receipt.timeZone
+            row.dateFormatter?.addWeekdayFormat()
         }.onChange({ [unowned self] row in
             self.receipt.date = row.value ?? Date()
         }).cellSetup({ cell, _ in

--- a/SmartReceipts/Modules/Edit Receipt/EditReceiptFormView.swift
+++ b/SmartReceipts/Modules/Edit Receipt/EditReceiptFormView.swift
@@ -60,6 +60,7 @@ class EditReceiptFormView: FormViewController, QuickAlertPresenter {
         } else {
             self.receipt = receipt!.copy() as? WBReceipt
             self.exchangeRateCalculator.price = receipt?.price().amount.doubleValue ?? 0
+            self.exchangeRateCalculator.exchangeRate = receipt?.exchangeRate?.doubleValue ?? 0
         }
         
         // Check conditions for automatic tax calculator
@@ -217,6 +218,9 @@ class EditReceiptFormView: FormViewController, QuickAlertPresenter {
                 let picker = self.form.rowBy(tag: self.CURRENCY_ROW_TAG) as? PickerInlineRow<String>
                 return picker?.value == self.trip.defaultCurrency.code
             })
+            
+            row.value = self.exchangeRateCalculator.price * self.exchangeRateCalculator.exchangeRate
+            
             self.exchangeRateCalculator.baseCurrencyPriceUpdate
                 .filter({ _ in !row.cell.textField.isEditing })
                 .subscribe(onNext: { [unowned self] in

--- a/SmartReceipts/Modules/Edit Trip/EditTripFormView.swift
+++ b/SmartReceipts/Modules/Edit Trip/EditTripFormView.swift
@@ -69,6 +69,7 @@ class EditTripFormView: FormViewController {
             row.title = LocalizedString("DIALOG_TRIPMENU_HINT_START")
             row.value = trip?.startDate
             row.dateFormatter?.timeZone = trip?.startTimeZone
+            row.dateFormatter?.addWeekdayFormat()
         }.onChange({ [unowned self] row in
             self.trip?.startDate = row.value!
             let endDateRow = self.form.rowBy(tag: self.END_DATE_TAG) as! DateInlineRow
@@ -83,6 +84,7 @@ class EditTripFormView: FormViewController {
             row.title = LocalizedString("DIALOG_TRIPMENU_HINT_END")
             row.value = trip?.endDate
             row.dateFormatter?.timeZone = trip?.endTimeZone
+            row.dateFormatter?.addWeekdayFormat()
         }.onChange({ [unowned self] row in
             self.trip?.endDate = row.value!
             let startDateRow = self.form.rowBy(tag: self.START_DATE_TAG) as! DateInlineRow

--- a/SmartReceipts/Modules/Generate Report/GenerateReportFormView.swift
+++ b/SmartReceipts/Modules/Generate Report/GenerateReportFormView.swift
@@ -13,7 +13,7 @@ import RxSwift
 class GenerateReportFormView: FormViewController {
     private(set) var selection = GenerateReportSelection()
     private var settingsTapSubject = PublishSubject<Void>()
-    
+
     var onSettingsTap: Observable<Void> { return settingsTapSubject.asObservable() }
 
     override func viewDidLoad() {


### PR DESCRIPTION
- Fixed Base Currency Price for Edit Mode
- Added Weekday to Date inline rows
- [Fix] Generate ZIP for Report without files
- [Fix] NavigationBar on iPad (iOS 10.3)
- [Fix] show Autocomptions by focus on predictiveCell
- [Fix] issue in which the date's always default to the trip start date